### PR TITLE
Add support for recording from Bluetooth devices

### DIFF
--- a/packages/expo-audio-stream/ios/AudioStreamManager.swift
+++ b/packages/expo-audio-stream/ios/AudioStreamManager.swift
@@ -212,8 +212,7 @@ class AudioStreamManager: NSObject {
                 newSettings.sampleRate = session.sampleRate
             }
             
-            try session.setCategory(.playAndRecord)
-            try session.setMode(.default)
+            try session.setCategory(.playAndRecord, mode: .default, options: [.allowBluetooth])
             try session.setPreferredSampleRate(settings.sampleRate)
             try session.setPreferredIOBufferDuration(1024 / settings.sampleRate)
             try session.setActive(true)


### PR DESCRIPTION
Setting this option allows microphone input from Bluetooth devices (such as Airpods). Tested locally by editing build files in XCode.

[Apple Documentation](https://developer.apple.com/documentation/avfaudio/avaudiosession/categoryoptions/1616518-allowbluetooth)