### PR TITLE
Remove frequently-firing log line

### DIFF
--- a/packages/expo-audio-stream/src/workers/InlineFeaturesExtractor.web.tsx
+++ b/packages/expo-audio-stream/src/workers/InlineFeaturesExtractor.web.tsx
@@ -13,8 +13,6 @@ self.onmessage = function (event) {
         numberOfChannels,
         features: _features,
     } = event.data
-
-    console.log('[AudioFeaturesExtractor] Worker received message', event.data)
     const features = _features || {}
 
     const SILENCE_THRESHOLD = 0.01


### PR DESCRIPTION
During medium/long sessions this made it hard to read other console logs.