### PR TITLE
fixed link in header of docs site

### DIFF
--- a/documentation_site/docusaurus.config.ts
+++ b/documentation_site/docusaurus.config.ts
@@ -63,7 +63,7 @@ const config: Config = {
           label: 'Docs',
         },
         {
-          href: 'https://github.com/siteed/expo-audio-stream',
+          href: 'https://github.com/deeeed/expo-audio-stream',
           label: 'GitHub',
           position: 'right',
         },


### PR DESCRIPTION
The header linked to your old GitHub account rather than the current one 😄 