### PR TITLE
fix(expo-audio-stream): bug in pause logic and types for pauseRecording/resumeRecording

### DIFF
--- a/documentation_site/docs/hooks/use-audio-recorder.md
+++ b/documentation_site/docs/hooks/use-audio-recorder.md
@@ -95,12 +95,12 @@ The `useAudioRecorder` hook returns an object with the following properties:
 
 - **pauseRecording**: Function to pause the current recording.
     ```ts
-    pauseRecording: () => void
+    pauseRecording: () => Promise<void>
     ```
 
 - **resumeRecording**: Function to resume a paused recording.
     ```ts
-    resumeRecording: () => void
+    resumeRecording: () => Promise<void>
     ```
 
 - **isRecording**: `boolean` - Indicates if recording is in progress.

--- a/packages/expo-audio-stream/ios/AudioStreamManager.swift
+++ b/packages/expo-audio-stream/ios/AudioStreamManager.swift
@@ -516,6 +516,7 @@ class AudioStreamManager: NSObject {
             startTime = Date()
             try audioEngine.start()
             isRecording = true
+            isPaused = false
             Logger.debug("Debug: Recording started successfully.")
             return StartRecordingResult(
                 fileUri: recordingFileURL!.path,
@@ -651,6 +652,7 @@ class AudioStreamManager: NSObject {
         audioEngine.stop()
         audioEngine.inputNode.removeTap(onBus: 0)
         isRecording = false
+        isPaused = false
         
         if recordingSettings?.showNotification == true {
             // Stop and clean up timer

--- a/packages/expo-audio-stream/src/AudioRecorder.provider.tsx
+++ b/packages/expo-audio-stream/src/AudioRecorder.provider.tsx
@@ -15,10 +15,10 @@ const initContext: UseAudioRecorderState = {
     stopRecording: async () => {
         throw new Error('AudioRecorderProvider not found')
     },
-    pauseRecording: () => {
+    pauseRecording: async () => {
         throw new Error('AudioRecorderProvider not found')
     },
-    resumeRecording: () => {
+    resumeRecording: async () => {
         throw new Error('AudioRecorderProvider not found')
     },
 }

--- a/packages/expo-audio-stream/src/ExpoAudioStream.types.ts
+++ b/packages/expo-audio-stream/src/ExpoAudioStream.types.ts
@@ -177,8 +177,8 @@ export interface WaveformConfig {
 export interface UseAudioRecorderState {
     startRecording: (_: RecordingConfig) => Promise<StartRecordingResult>
     stopRecording: () => Promise<AudioRecording | null>
-    pauseRecording: () => void
-    resumeRecording: () => void
+    pauseRecording: () => Promise<void>
+    resumeRecording: () => Promise<void>
     isRecording: boolean
     isPaused: boolean
     durationMs: number // Duration of the recording

--- a/packages/expo-audio-stream/src/ExpoAudioStream.web.ts
+++ b/packages/expo-audio-stream/src/ExpoAudioStream.web.ts
@@ -141,6 +141,7 @@ export class ExpoAudioStreamWeb extends EventEmitter {
         this.recordingConfig = recordingConfig
         this.recordingStartTime = Date.now()
         this.pausedTime = 0
+        this.isPaused = false
         this.lastEmittedSize = 0
         this.lastEmittedTime = 0
         this.streamUuid = Date.now().toString()
@@ -182,6 +183,7 @@ export class ExpoAudioStreamWeb extends EventEmitter {
         // concat all audio chunks
         logger.debug(`Stopped recording`, fullPcmBufferArray)
         this.isRecording = false
+        this.isPaused = false
         this.currentDurationMs = Date.now() - this.recordingStartTime
 
         // Rewrite wav header with correct data size

--- a/packages/expo-audio-stream/src/useAudioRecorder.tsx
+++ b/packages/expo-audio-stream/src/useAudioRecorder.tsx
@@ -29,8 +29,8 @@ export interface UseAudioRecorderProps {
 export interface UseAudioRecorderState {
     startRecording: (_: RecordingConfig) => Promise<StartRecordingResult>
     stopRecording: () => Promise<AudioRecording>
-    pauseRecording: () => void
-    resumeRecording: () => void
+    pauseRecording: () => Promise<void>
+    resumeRecording: () => Promise<void>
     isRecording: boolean
     isPaused: boolean
     durationMs: number // Duration of the recording


### PR DESCRIPTION
There is a small bug where pausing/resuming a recording causes issues since the internal state of web/ios does not set the `(this).isPaused = false`.

I also fixed the types of `pauseRecording` and `resumeRecording` since those are async functions and useful in application logic for waiting until the pause/resume is finished