### PR TITLE
updated min interval on android to 10ms (from 100ms)

### DIFF
--- a/packages/expo-audio-stream/android/src/main/java/net/siteed/audiostream/Constants.kt
+++ b/packages/expo-audio-stream/android/src/main/java/net/siteed/audiostream/Constants.kt
@@ -7,7 +7,7 @@ object Constants {
     const val DEFAULT_CHANNEL_CONFIG = 1 // Mono
     const val DEFAULT_AUDIO_FORMAT = 16 // 16-bit PCM
     const val DEFAULT_INTERVAL = 1000L
-    const val MIN_INTERVAL = 100L // Minimum interval in ms for emitting audio data
+    const val MIN_INTERVAL = 10L // Minimum interval in ms for emitting audio data
     const val WAV_HEADER_SIZE = 44
     const val RIFF_HEADER = 0x52494646 // "RIFF"
     const val WAVE_HEADER = 0x57415645 // "WAVE"


### PR DESCRIPTION
Going off of #31, this allows applications to set the audio interval to 10ms. I tested it at 20ms without issues, so I put it at 10ms to enable other devs to experiment.