### PR TITLE
feat(expo-audio-stream): add comprehensive ios audio session configuration support

### DIFF
--- a/apps/playground/src/AppRoot.tsx
+++ b/apps/playground/src/AppRoot.tsx
@@ -6,7 +6,6 @@ import { setLoggerConfig } from '@siteed/react-native-logger'
 import { App as ExpoRouterApp } from 'expo-router/build/qualified-entry'
 import { StatusBar } from 'expo-status-bar'
 import { useEffect, useState } from 'react'
-import { Platform } from 'react-native'
 import { ActivityIndicator } from 'react-native-paper'
 
 import { useReanimatedWebHack } from './hooks/useReanimatedWebHack'
@@ -14,7 +13,6 @@ import { useReanimatedWebHack } from './hooks/useReanimatedWebHack'
 setLoggerConfig({
     namespaces: '*',
     maxLogs: 20,
-    disableExtraParamsInConsole: Platform.OS !== 'web',
 })
 
 export const WithUIProvider = ({ children }: { children: React.ReactNode }) => {

--- a/apps/playground/src/app/(tabs)/record.tsx
+++ b/apps/playground/src/app/(tabs)/record.tsx
@@ -616,8 +616,6 @@ export default function RecordScreen() {
                     />
                     {iosSettingsEnabled && (
                         <IOSSettingsConfig
-                            enabled={iosSettingsEnabled}
-                            onEnabledChange={setIOSSettingsEnabled}
                             config={iosSettings}
                             onConfigChange={(newConfig) => {
                                 console.debug(`New iOS config`, newConfig)

--- a/apps/playground/src/component/IOSSettingsConfig.tsx
+++ b/apps/playground/src/component/IOSSettingsConfig.tsx
@@ -9,8 +9,6 @@ import { IOSSettingsConfigForm } from './IOSSettingsConfigForm'
 const logger = getLogger('IOSSettingsConfig')
 
 interface IOSSettingsConfigProps {
-    enabled: boolean
-    onEnabledChange: (enabled: boolean) => void
     config?: RecordingConfig['ios']
     onConfigChange: (config: RecordingConfig['ios']) => void
 }

--- a/apps/playground/src/component/IOSSettingsConfig.tsx
+++ b/apps/playground/src/component/IOSSettingsConfig.tsx
@@ -1,0 +1,78 @@
+import { EditableInfoCard, useModal } from '@siteed/design-system'
+import { RecordingConfig } from '@siteed/expo-audio-stream'
+import { getLogger } from '@siteed/react-native-logger'
+import React, { useState } from 'react'
+import { Platform, StyleSheet, View } from 'react-native'
+
+import { IOSSettingsConfigForm } from './IOSSettingsConfigForm'
+
+const logger = getLogger('IOSSettingsConfig')
+
+interface IOSSettingsConfigProps {
+    enabled: boolean
+    onEnabledChange: (enabled: boolean) => void
+    config?: RecordingConfig['ios']
+    onConfigChange: (config: RecordingConfig['ios']) => void
+}
+
+export const IOSSettingsConfig = ({
+    config,
+    onConfigChange,
+}: IOSSettingsConfigProps) => {
+    const { openDrawer } = useModal()
+    const [localConfig, setLocalConfig] = useState(config)
+
+    const handleEditConfig = async () => {
+        try {
+            const result = await openDrawer({
+                initialData: localConfig ?? { audioSession: {} },
+                bottomSheetProps: {
+                    snapPoints: ['80%'],
+                    enableDynamicSizing: false,
+                },
+                containerType: 'scrollview',
+                title: 'iOS Audio Settings',
+                footerType: 'confirm_cancel',
+                render: ({ data, onChange }) => (
+                    <IOSSettingsConfigForm
+                        config={data}
+                        onConfigChange={(newConfig) => {
+                            onChange(newConfig)
+                            setLocalConfig(newConfig)
+                        }}
+                    />
+                ),
+            })
+
+            if (result) {
+                logger.debug(`New iOS config`, result)
+                onConfigChange(result)
+            }
+        } catch (error) {
+            logger.error(`Failed to change iOS config`, error)
+        }
+    }
+
+    // Only show on iOS
+    if (Platform.OS !== 'ios') {
+        return null
+    }
+
+    return (
+        <View style={styles.container}>
+            <EditableInfoCard
+                label="iOS Audio Settings"
+                value={JSON.stringify(localConfig?.audioSession ?? {}, null, 2)}
+                containerStyle={{ margin: 0 }}
+                editable
+                onEdit={handleEditConfig}
+            />
+        </View>
+    )
+}
+
+const styles = StyleSheet.create({
+    container: {
+        gap: 16,
+    },
+})

--- a/apps/playground/src/component/IOSSettingsConfigForm.tsx
+++ b/apps/playground/src/component/IOSSettingsConfigForm.tsx
@@ -1,0 +1,172 @@
+import { Picker, SelectOption } from '@siteed/design-system'
+import { IOSConfig, AudioSessionConfig } from '@siteed/expo-audio-stream'
+import { getLogger } from '@siteed/react-native-logger'
+import React, { useCallback, useState } from 'react'
+import { StyleSheet, View } from 'react-native'
+
+const logger = getLogger('IOSSettingsConfigForm')
+
+interface IOSSettingsConfigFormProps {
+    config: IOSConfig
+    onConfigChange: (config: IOSConfig) => void
+}
+
+export const IOSSettingsConfigForm = ({
+    config = {
+        audioSession: {
+            category: undefined,
+            mode: undefined,
+            categoryOptions: undefined,
+        },
+    },
+    onConfigChange,
+}: IOSSettingsConfigFormProps) => {
+    const [localConfig, setLocalConfig] = useState(config)
+
+    const handleCategoryFinish = useCallback(
+        (selectedOptions: SelectOption[]) => {
+            const selected = selectedOptions.find((option) => option.selected)
+            if (!selected) return
+
+            const newConfig = {
+                ...localConfig,
+                audioSession: {
+                    ...localConfig.audioSession,
+                    category: selected.value as AudioSessionConfig['category'],
+                },
+            }
+            logger.debug('Updating category config:', newConfig)
+            setLocalConfig(newConfig)
+            onConfigChange(newConfig)
+        },
+        [localConfig, onConfigChange]
+    )
+
+    const handleModeFinish = useCallback(
+        (selectedOptions: SelectOption[]) => {
+            const selected = selectedOptions.find((option) => option.selected)
+            if (!selected) return
+
+            const newConfig = {
+                ...localConfig,
+                audioSession: {
+                    ...localConfig.audioSession,
+                    mode: selected.value as AudioSessionConfig['mode'],
+                },
+            }
+            logger.debug('Updating mode config:', newConfig)
+            setLocalConfig(newConfig)
+            onConfigChange(newConfig)
+        },
+        [localConfig, onConfigChange]
+    )
+
+    const handleOptionsFinish = useCallback(
+        (selectedOptions: SelectOption[]) => {
+            const selectedValues = selectedOptions
+                .filter((option) => option.selected)
+                .map((option) => option.value) as NonNullable<
+                AudioSessionConfig['categoryOptions']
+            >
+
+            const newConfig = {
+                ...localConfig,
+                audioSession: {
+                    ...localConfig.audioSession,
+                    categoryOptions: selectedValues,
+                },
+            }
+            logger.debug('Updating options config:', newConfig)
+            setLocalConfig(newConfig)
+            onConfigChange(newConfig)
+        },
+        [localConfig, onConfigChange]
+    )
+
+    return (
+        <View style={styles.container}>
+            <Picker
+                label="Audio Category"
+                multi={false}
+                options={categories.map(
+                    (category): SelectOption => ({
+                        label: category,
+                        value: category,
+                        selected:
+                            localConfig.audioSession?.category === category,
+                    })
+                )}
+                onFinish={handleCategoryFinish}
+            />
+
+            <Picker
+                label="Audio Mode"
+                multi={false}
+                options={modes.map(
+                    (mode): SelectOption => ({
+                        label: mode,
+                        value: mode,
+                        selected: localConfig.audioSession?.mode === mode,
+                    })
+                )}
+                onFinish={handleModeFinish}
+            />
+
+            <Picker
+                label="Category Options"
+                multi
+                options={categoryOptions.map(
+                    (option): SelectOption => ({
+                        label: option,
+                        value: option,
+                        selected: Boolean(
+                            localConfig.audioSession?.categoryOptions?.includes(
+                                option
+                            )
+                        ),
+                    })
+                )}
+                onFinish={handleOptionsFinish}
+            />
+        </View>
+    )
+}
+
+const categoryOptions: NonNullable<
+    AudioSessionConfig['categoryOptions']
+>[number][] = [
+    'MixWithOthers',
+    'DuckOthers',
+    'InterruptSpokenAudioAndMixWithOthers',
+    'AllowBluetooth',
+    'AllowBluetoothA2DP',
+    'AllowAirPlay',
+    'DefaultToSpeaker',
+]
+
+const categories: NonNullable<AudioSessionConfig['category']>[] = [
+    'Ambient',
+    'SoloAmbient',
+    'Playback',
+    'Record',
+    'PlayAndRecord',
+    'MultiRoute',
+]
+
+const modes: NonNullable<AudioSessionConfig['mode']>[] = [
+    'Default',
+    'VoiceChat',
+    'VideoChat',
+    'GameChat',
+    'VideoRecording',
+    'Measurement',
+    'MoviePlayback',
+    'SpokenAudio',
+]
+
+const styles = StyleSheet.create({
+    container: {
+        gap: 16,
+        padding: 16,
+    },
+})

--- a/packages/expo-audio-stream/ios/RecordingSettings.swift
+++ b/packages/expo-audio-stream/ios/RecordingSettings.swift
@@ -1,13 +1,20 @@
 // RecordingSettings.swift
 
+import AVFoundation
+
 struct NotificationAction {
     var title: String
     var identifier: String
 }
 
+struct IOSAudioSessionConfig {
+    var category: AVAudioSession.Category
+    var mode: AVAudioSession.Mode
+    var categoryOptions: AVAudioSession.CategoryOptions
+}
+
 struct IOSNotificationConfig {
     var categoryIdentifier: String?
-    var actions: [NotificationAction]?
 }
 
 struct NotificationConfig {
@@ -15,6 +22,10 @@ struct NotificationConfig {
     var text: String?
     var icon: String?
     var ios: IOSNotificationConfig?
+}
+
+struct IOSConfig {
+    var audioSession: IOSAudioSessionConfig?
 }
 
 struct RecordingSettings {
@@ -34,6 +45,9 @@ struct RecordingSettings {
     var pointsPerSecond: Int? = 1000
     var algorithm: String? = "rms"
     var featureOptions: [String: Bool]? = ["rms": true, "zcr": true]
+    
+    // iOS-specific configuration
+    var ios: IOSConfig?
     
     // Notification configuration
     var notification: NotificationConfig?
@@ -59,6 +73,68 @@ struct RecordingSettings {
         settings.algorithm = dict["algorithm"] as? String
         settings.featureOptions = dict["features"] as? [String: Bool]
         
+        // Parse iOS-specific config
+        if let iosDict = dict["ios"] as? [String: Any],
+           let audioSessionDict = iosDict["audioSession"] as? [String: Any] {
+            
+            // Map category
+            let category: AVAudioSession.Category
+            if let categoryStr = audioSessionDict["category"] as? String {
+                switch categoryStr {
+                    case "Ambient": category = .ambient
+                    case "SoloAmbient": category = .soloAmbient
+                    case "Playback": category = .playback
+                    case "Record": category = .record
+                    case "PlayAndRecord": category = .playAndRecord
+                    case "MultiRoute": category = .multiRoute
+                    default: category = .record
+                }
+            } else {
+                category = .record
+            }
+            
+            // Map mode
+            let mode: AVAudioSession.Mode
+            if let modeStr = audioSessionDict["mode"] as? String {
+                switch modeStr {
+                    case "Default": mode = .default
+                    case "VoiceChat": mode = .voiceChat
+                    case "VideoChat": mode = .videoChat
+                    case "GameChat": mode = .gameChat
+                    case "VideoRecording": mode = .videoRecording
+                    case "Measurement": mode = .measurement
+                    case "MoviePlayback": mode = .moviePlayback
+                    case "SpokenAudio": mode = .spokenAudio
+                    default: mode = .default
+                }
+            } else {
+                mode = .default
+            }
+            
+            // Map category options
+            var categoryOptions: AVAudioSession.CategoryOptions = []
+            if let optionsArray = audioSessionDict["categoryOptions"] as? [String] {
+                for option in optionsArray {
+                    switch option {
+                        case "MixWithOthers": categoryOptions.insert(.mixWithOthers)
+                        case "DuckOthers": categoryOptions.insert(.duckOthers)
+                        case "InterruptSpokenAudioAndMixWithOthers": categoryOptions.insert(.interruptSpokenAudioAndMixWithOthers)
+                        case "AllowBluetooth": categoryOptions.insert(.allowBluetooth)
+                        case "AllowBluetoothA2DP": categoryOptions.insert(.allowBluetoothA2DP)
+                        case "AllowAirPlay": categoryOptions.insert(.allowAirPlay)
+                        case "DefaultToSpeaker": categoryOptions.insert(.defaultToSpeaker)
+                        default: break
+                    }
+                }
+            }
+            
+            settings.ios = IOSConfig(audioSession: IOSAudioSessionConfig(
+                category: category,
+                mode: mode,
+                categoryOptions: categoryOptions
+            ))
+        }
+        
         // Parse notification config
         if let notificationDict = dict["notification"] as? [String: Any] {
             var notificationConfig = NotificationConfig()
@@ -67,20 +143,10 @@ struct RecordingSettings {
             notificationConfig.icon = notificationDict["icon"] as? String
             
             // Parse iOS-specific notification config
-            if let iosDict = notificationDict["ios"] as? [String: Any] {
-                var iosConfig = IOSNotificationConfig()
-                iosConfig.categoryIdentifier = iosDict["categoryIdentifier"] as? String
-                
-                if let actionsArray = iosDict["actions"] as? [[String: Any]] {
-                    iosConfig.actions = actionsArray.map { actionDict in
-                        NotificationAction(
-                            title: actionDict["title"] as? String ?? "",
-                            identifier: actionDict["identifier"] as? String ?? ""
-                        )
-                    }
-                }
-                
-                notificationConfig.ios = iosConfig
+            if let iosNotificationDict = notificationDict["ios"] as? [String: Any] {
+                notificationConfig.ios = IOSNotificationConfig(
+                    categoryIdentifier: iosNotificationDict["categoryIdentifier"] as? String
+                )
             }
             
             settings.notification = notificationConfig

--- a/packages/expo-audio-stream/src/ExpoAudioStream.types.ts
+++ b/packages/expo-audio-stream/src/ExpoAudioStream.types.ts
@@ -70,6 +70,38 @@ export interface StartRecordingResult {
     sampleRate?: SampleRate
 }
 
+export interface AudioSessionConfig {
+    category?:
+        | 'Ambient'
+        | 'SoloAmbient'
+        | 'Playback'
+        | 'Record'
+        | 'PlayAndRecord'
+        | 'MultiRoute'
+    mode?:
+        | 'Default'
+        | 'VoiceChat'
+        | 'VideoChat'
+        | 'GameChat'
+        | 'VideoRecording'
+        | 'Measurement'
+        | 'MoviePlayback'
+        | 'SpokenAudio'
+    categoryOptions?: (
+        | 'MixWithOthers'
+        | 'DuckOthers'
+        | 'InterruptSpokenAudioAndMixWithOthers'
+        | 'AllowBluetooth'
+        | 'AllowBluetoothA2DP'
+        | 'AllowAirPlay'
+        | 'DefaultToSpeaker'
+    )[]
+}
+
+export interface IOSConfig {
+    audioSession?: AudioSessionConfig
+}
+
 export interface RecordingConfig {
     // Sample rate for recording (16000, 44100, or 48000 Hz)
     sampleRate?: SampleRate
@@ -97,6 +129,9 @@ export interface RecordingConfig {
 
     // Enable audio processing (default is false)
     enableProcessing?: boolean
+
+    // iOS-specific configuration
+    ios?: IOSConfig
 
     // Number of data points to extract per second of audio (default is 1000)
     pointsPerSecond?: number


### PR DESCRIPTION
# Description
## Overview
This PR introduces comprehensive iOS audio session configuration capabilities, allowing fine-grained control over audio behavior in iOS devices. The implementation enables developers to customize audio categories, modes, and category options through a new user interface in the playground app.

## Key Changes
- Added new iOS audio session configuration types and interfaces
- Implemented configuration UI components with form controls
- Enhanced Swift implementation to handle custom audio session settings
- Added detailed logging for audio session configuration
- Set sensible defaults while maintaining backward compatibility

## Implementation Details
### New Components
- `IOSSettingsConfig`: Main configuration component with edit capabilities
- `IOSSettingsConfigForm`: Form component for audio session settings with:
  - Audio category selection (Ambient, PlayAndRecord, etc.)
  - Audio mode selection (Default, SpokenAudio, etc.)
  - Category options multi-select (MixWithOthers, AllowBluetooth, etc.)

### Type System Updates
- Added `AudioSessionConfig` interface for type-safe configuration
- Introduced `IOSConfig` interface for iOS-specific settings
- Enhanced `RecordingConfig` to support iOS-specific configurations

### Native Implementation
- Updated `AudioStreamManager.swift` to handle custom audio session configurations
- Enhanced `RecordingSettings.swift` with new iOS configuration parsing
- Added comprehensive logging for audio session setup and configuration
