### PR TITLE
fix: reset audio recording state properly on iOS and Android

### DIFF
--- a/packages/expo-audio-stream/android/src/main/java/net/siteed/audiostream/AudioRecorderManager.kt
+++ b/packages/expo-audio-stream/android/src/main/java/net/siteed/audiostream/AudioRecorderManager.kt
@@ -339,6 +339,7 @@ class AudioRecorderManager(
         try {
             streamUuid = java.util.UUID.randomUUID().toString()
             audioFile = File(filesDir, "audio_${streamUuid}.$fileExtension")
+            totalDataSize = 0
 
             FileOutputStream(audioFile, true).use { fos ->
                 audioFileHandler.writeWavHeader(

--- a/packages/expo-audio-stream/ios/AudioStreamManager.swift
+++ b/packages/expo-audio-stream/ios/AudioStreamManager.swift
@@ -435,6 +435,7 @@ class AudioStreamManager: NSObject {
         accumulatedData.removeAll()
         totalDataSize = 0
         pausedDuration = 0
+        lastEmittedSize = 0
         isPaused = false
         
         do {


### PR DESCRIPTION
# Description
Fixes issues with audio recording state management across platforms:
- iOS: Initial position carries over from previous recordings
- Android: Total size counter not resetting between recordings

## Changes
- iOS: Reset `lastEmittedSize` when starting new recording
- Android: Reset `totalDataSize` when initializing new recording file

No breaking changes or migration steps required.