### PR TITLE
fix(ios): improve audio resampling and duration tracking

### DIFF
--- a/documentation_site/docs/api-reference/recording-config.md
+++ b/documentation_site/docs/api-reference/recording-config.md
@@ -42,22 +42,21 @@ On Android, the recording is managed using Android's native `AudioRecord` API al
 
 ### iOS
 
-On iOS, the recording is managed using `AVAudioEngine` and related classes from the `AVFoundation` framework. `AVAudioEngine` provides a robust and flexible way to capture, process, and play audio, making it ideal for real-time audio applications on iOS devices.
+On iOS, the recording is managed using `AVAudioEngine` and related classes from the `AVFoundation` framework. The implementation uses a sophisticated resampling approach that:
+- Captures audio at the hardware's native sample rate
+- Performs high-quality resampling to match the requested configuration
+- Supports both 16-bit and 32-bit PCM formats
+- Maintains audio quality through intermediate Float32 format when necessary
 
 ## Platform Differences
 
 ### Android and iOS
 
-On Android and iOS, the library attempts to record audio in the specified format. However, due to platform limitations, it doesn't always natively allow obtaining the PCM output in the desired format. When this occurs, the recorded audio needs to be manually resampled to match the required configuration.
+On Android and iOS, the library attempts to record audio in the specified format. On iOS, the audio is automatically resampled to match the requested configuration using AVAudioConverter, ensuring high-quality output even when the hardware sample rate differs from the target rate.
 
 ### Web
 
 On the web, the default configuration is typically higher, with a 44.1kHz sample rate and 32-bit depth. This ensures better sound quality, but it can lead to issues when resampling is required to lower settings.
-
-## Current Challenges
-
-Currently, resampling audio to different sample rates and bit depths is not producing the desired quality results. This is an ongoing area of investigation to ensure that resampling defaults to lower settings without breaking the sound quality.
-
 
 ## Recording Process 
 

--- a/packages/expo-audio-stream/ios/ExpoAudioStreamModule.swift
+++ b/packages/expo-audio-stream/ios/ExpoAudioStreamModule.swift
@@ -317,13 +317,13 @@ public class ExpoAudioStreamModule: Module, AudioStreamManagerDelegate {
         let sampleRate = settings.sampleRate
         let channels = Double(settings.numberOfChannels)
         let bitDepth = Double(settings.bitDepth)
-        let position = Int((Double(manager.lastEmittedSize) / (sampleRate * channels * (bitDepth / 8))) * 1000)
+        let position = Int(manager.currentRecordingDuration() * 1000)
         
         // Construct the event payload similar to Android
         let eventBody: [String: Any] = [
             "fileUri": fileURL.absoluteString,
             "lastEmittedSize": manager.lastEmittedSize,  // Needs to be maintained within AudioStreamManager
-            "position": position, // Add position of the chunk in ms since
+            "position": position, // time in ms based on pause-aware duration
             "encoded": encodedData,
             "deltaSize": deltaSize,
             "totalSize": fileSize,


### PR DESCRIPTION
# Description
## Overview
This PR addresses two key issues in the iOS audio implementation:
1. Improves handling of custom sampling rates through proper resampling (fixes #62)
2. Fixes duration calculation bugs during pause/resume operations

## Key Changes

### Audio Resampling
- Implemented high-quality resampling using `AVAudioConverter` to properly handle requested sampling rates
- Added intermediate Float32 format processing for better quality preservation
- Improved hardware sample rate detection and fallback behavior
- Enhanced logging for debugging sample rate issues

### Duration Tracking
- Fixed duration calculation when pausing/resuming multiple times
- Replaced `pausedDuration` with more accurate `totalPausedDuration` tracking
- Added `currentPauseStart` to properly handle pause states
- Updated duration calculations to be based on actual audio data size

## Implementation Details
- Uses `AVAudioConverter` for sample rate conversion
- Maintains audio quality through intermediate Float32 format when necessary
- Tracks pause durations independently of the audio engine state
- Improved error handling throughout the conversion pipeline

## Related Issues
- Fixes #62 (sampling rate fallback on iOS 18.2)
- Fixes duration reporting during pause/resume operations

No breaking changes - this PR maintains backward compatibility while improving internal implementation.