### PR TITLE
fix: prevent duplicate notifications during audio recording on Android

### DIFF
--- a/packages/expo-audio-stream/android/src/main/java/net/siteed/audiostream/AudioNotificationsManager.kt
+++ b/packages/expo-audio-stream/android/src/main/java/net/siteed/audiostream/AudioNotificationsManager.kt
@@ -275,14 +275,17 @@ class AudioNotificationManager private constructor(context: Context) {
                 notificationBuilder
                     .setCustomContentView(remoteViews)
                     .setCustomBigContentView(remoteViews)
-                    .clearActions()
+                    .setOnlyAlertOnce(true)
+                    .setOngoing(true)
                 addNotificationActions(context)
             }
 
-            // Update the notification
+            // Update the notification without triggering a new alert
             notificationManager.notify(
                 recordingConfig.notification.notificationId,
-                notificationBuilder.build()
+                notificationBuilder
+                    .setOnlyAlertOnce(true)
+                    .build()
             )
 
             lastSuccessfulUpdate = currentTime


### PR DESCRIPTION
# Description
## Problem
The audio recording notification was incorrectly triggering multiple alerts when updating its content (e.g., recording duration updates). This caused unnecessary notification alerts throughout the recording session, affecting both the device and any connected accessories.

## Solution
Modified the notification configuration to properly update the existing notification instead of triggering new alerts:
```diff
- .clearActions()
+ .setOnlyAlertOnce(true)
+ .setOngoing(true)
```

These minimal changes ensure:
- Only one notification alert occurs when recording starts
- Subsequent notification updates happen silently
- The notification properly indicates its ongoing status

## Implementation Details
- `setOnlyAlertOnce(true)`: Ensures notification updates don't trigger new alerts
- `setOngoing(true)`: Indicates this is a continuous notification
- Removed unnecessary `clearActions()` call as actions are managed separately


# Notes
- No breaking changes
- No migration steps required
- Focused fix for notification behavior