### PR TITLE
feat: disable duplicate notification alerts for audio stream

### DIFF
--- a/packages/expo-audio-stream/android/src/main/java/net/siteed/audiostream/AudioNotificationsManager.kt
+++ b/packages/expo-audio-stream/android/src/main/java/net/siteed/audiostream/AudioNotificationsManager.kt
@@ -126,6 +126,10 @@ class AudioNotificationManager private constructor(context: Context) {
             .setCustomContentView(remoteViews)
             .setCustomBigContentView(remoteViews)
             .setStyle(NotificationCompat.DecoratedCustomViewStyle())
+            .setOnlyAlertOnce(true)
+            .setVibrate(null)
+            .setDefaults(0)
+            .setLocalOnly(true)
 
         addNotificationActions(context)
     }

--- a/packages/expo-audio-stream/android/src/main/java/net/siteed/audiostream/AudioNotificationsManager.kt
+++ b/packages/expo-audio-stream/android/src/main/java/net/siteed/audiostream/AudioNotificationsManager.kt
@@ -115,10 +115,12 @@ class AudioNotificationManager private constructor(context: Context) {
             PendingIntent.FLAG_IMMUTABLE
         )
 
+        // Configure notification builder with settings optimized for recording service
+        // and wearable device compatibility
         notificationBuilder = NotificationCompat.Builder(context, recordingConfig.notification.channelId)
             .setSmallIcon(iconResId)
             .setContentIntent(pendingIntent)
-            .setOngoing(true)
+            .setOngoing(true)  // Notification cannot be dismissed by user
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setCategory(NotificationCompat.CATEGORY_SERVICE)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
@@ -126,10 +128,11 @@ class AudioNotificationManager private constructor(context: Context) {
             .setCustomContentView(remoteViews)
             .setCustomBigContentView(remoteViews)
             .setStyle(NotificationCompat.DecoratedCustomViewStyle())
-            .setOnlyAlertOnce(true)
-            .setVibrate(null)
-            .setDefaults(0)
-            .setLocalOnly(true)
+            // Prevent repeated alerts and vibrations
+            .setOnlyAlertOnce(true)  // Only alert on first notification
+            .setVibrate(null)        // Disable vibration
+            .setDefaults(0)          // Clear all default notification behaviors
+            .setLocalOnly(true)      // Prevent notification from appearing on wearable devices
 
         addNotificationActions(context)
     }


### PR DESCRIPTION
# Description
This PR prevents duplicate notification alerts and constant vibrations on wearable devices by modifying notification settings in AudioNotificationsManager.

## Changes
- Added `setOnlyAlertOnce(true)` to prevent duplicate alerts
- Disabled vibration with `setVibrate(null)`
- Reset notification defaults with `setDefaults(0)`
- Set `setLocalOnly(true)` to limit notifications to the local device

## Impact
Improves user experience by:
- Preventing wearable devices from constantly vibrating
- Reducing notification fatigue
- Maintaining audio stream status visibility without disruption

No breaking changes or migration steps required.
