### PR TITLE
fix(plugin): remove automatic VoIP and audio background modes for iOS

### DIFF
--- a/apps/playground/src/AppRoot.tsx
+++ b/apps/playground/src/AppRoot.tsx
@@ -7,13 +7,15 @@ import { App as ExpoRouterApp } from 'expo-router/build/qualified-entry'
 import { StatusBar } from 'expo-status-bar'
 import { useEffect, useState } from 'react'
 import { ActivityIndicator } from 'react-native-paper'
+import { en, registerTranslation } from "react-native-paper-dates"
 import { Provider } from 'react-redux'
 
 import { PersistGate } from 'redux-persist/integration/react'
+import { baseLogger } from './config'
 import { useReanimatedWebHack } from './hooks/useReanimatedWebHack'
 import { persistor, setThemePreferences, store, useAppDispatch, useAppSelector } from './store'
-import { baseLogger } from './config'
 
+registerTranslation("en", en);
 setLoggerConfig({
     namespaces: '*',
     maxLogs: 20,

--- a/documentation_site/docs/installation.md
+++ b/documentation_site/docs/installation.md
@@ -43,7 +43,16 @@ You can customize the plugin's behavior by providing options:
                 {
                     "enablePhoneStateHandling": true,
                     "enableNotifications": true,
-                    "enableBackgroundAudio": true
+                    "enableBackgroundAudio": true,
+                    "iosBackgroundModes": {
+                        "useVoIP": false,
+                        "useAudio": false,
+                        "useProcessing": true
+                    },
+                    "iosConfig": {
+                        "backgroundProcessingTitle": "Audio Recording",
+                        "keepAliveInBackground": true
+                    }
                 }
             ]
         ]
@@ -53,9 +62,10 @@ You can customize the plugin's behavior by providing options:
 
 ### Configuration Options
 
+#### Core Options
 - **enablePhoneStateHandling** (default: `true`): 
   - Enables handling of phone state changes (calls, etc.)
-  - Adds telephony capabilities and VoIP background mode on iOS
+  - Adds telephony capabilities on iOS
   - Adds READ_PHONE_STATE permission on Android
 
 - **enableNotifications** (default: `true`):
@@ -65,8 +75,33 @@ You can customize the plugin's behavior by providing options:
 
 - **enableBackgroundAudio** (default: `true`):
   - Enables background audio recording capabilities
-  - Adds audio background mode on iOS
   - Adds FOREGROUND_SERVICE and FOREGROUND_SERVICE_MICROPHONE permissions on Android
+
+#### iOS Background Modes
+- **iosBackgroundModes**:
+  - `useVoIP` (default: `false`): Enable VoIP background mode
+  - `useAudio` (default: `false`): Enable audio background mode
+  - `useProcessing` (default: `false`): Enable background processing mode
+  - `useLocation` (default: `false`): Enable location updates in background
+  - `useExternalAccessory` (default: `false`): Enable external audio accessories
+
+#### iOS Specific Configuration
+- **iosConfig**:
+  - `allowBackgroundAudioControls` (default: `false`): Show audio controls in control center
+  - `backgroundProcessingTitle` (default: `'Audio Recording'`): Description for background processing
+  - `keepAliveInBackground` (default: `true`): Enable background keep-alive mechanisms
+
+### App Store Submission Notes
+
+When submitting to the App Store, it's important to configure the background modes appropriately to avoid rejection:
+
+1. If your app only needs background recording without playback:
+   - Set `useAudio` to `false`
+   - Use `useProcessing` instead for background operation
+
+2. If your app doesn't use VoIP features:
+   - Set `useVoIP` to `false`
+   - Use alternative background modes like `useProcessing` for background operation
 
 Make sure to run `npx expo prebuild` after modifying the plugin configuration in your app.json file.
 


### PR DESCRIPTION
# Description
## Issue
Fixes #85 - Apps using expo-audio-stream are getting rejected from the App Store due to automatic inclusion of VoIP and audio background modes, even when these modes aren't required for the app's functionality.

## Root Cause
The plugin was automatically adding VoIP and audio background modes to support background recording, but this approach conflicts with App Store guidelines which require these modes to be used only for their intended purposes:
- VoIP mode should only be used for actual Voice-over-IP functionality
- Audio background mode should only be used for audio playback, not recording

## Solution
This PR modifies the plugin to:
1. Disable VoIP and audio background modes by default
2. Use background processing mode as the default mechanism for background recording
3. Add explicit configuration options for background modes
4. Update documentation with App Store submission guidance

### Changes
- Changed default values:
  ```ts
  iosBackgroundModes: {
    useVoIP: false,    // Previously true
    useAudio: false,   // Previously true
    useProcessing: true // New default for background recording
  }
  ```
- Added clear documentation about which background modes to use for different scenarios
- Added App Store submission guidance section

## Migration Guide
If your app only needs background recording (no playback):
```json
{
  "plugins": [
    [
      "expo-audio-stream",
      {
        "iosBackgroundModes": {
          "useVoIP": false,
          "useAudio": false,
          "useProcessing": true
        },
        "iosConfig": {
          "backgroundProcessingTitle": "Audio Recording",
          "keepAliveInBackground": true
        }
      }
    ]
  ]
}
```

If your app needs background audio playback:
```json
{
  "plugins": [
    [
      "expo-audio-stream",
      {
        "iosBackgroundModes": {
          "useAudio": true
        }
      }
    ]
  ]
}
```
