### PR TITLE
feat: add custom filename and directory support for audio recordings

### DIFF
--- a/apps/playground/src/app/(tabs)/record.tsx
+++ b/apps/playground/src/app/(tabs)/record.tsx
@@ -301,8 +301,8 @@ export default function RecordScreen() {
         try {
             setProcessing(true)
             
-            // Ensure we have a valid directory
-            if (!defaultDirectory) {
+            // Only check directory on native platforms
+            if (Platform.OS !== 'web' && !defaultDirectory) {
                 throw new Error('Storage directory not initialized')
             }
 
@@ -448,6 +448,7 @@ export default function RecordScreen() {
         } finally {
             setStopping(false)
             setProcessing(false)
+            setCustomFileName('')
         }
     }, [stopRecording, enableLiveTranscription, router, show, hide, transcripts, refreshFiles])
 
@@ -824,6 +825,7 @@ export default function RecordScreen() {
     }, [notificationEnabled, notificationConfig, iosSettings])
 
     useEffect(() => {
+        if(isWeb) return
         async function initializeDefaultDirectory() {
             try {
                 // Use documentDirectory for both iOS and Android

--- a/apps/playground/src/component/IOSSettingsConfig.tsx
+++ b/apps/playground/src/component/IOSSettingsConfig.tsx
@@ -24,10 +24,6 @@ export const IOSSettingsConfig = ({
         try {
             const result = await openDrawer({
                 initialData: localConfig ?? { audioSession: {} },
-                bottomSheetProps: {
-                    snapPoints: ['80%'],
-                    enableDynamicSizing: false,
-                },
                 containerType: 'scrollview',
                 title: 'iOS Audio Settings',
                 footerType: 'confirm_cancel',

--- a/apps/playground/src/component/NativeNotificationConfig.tsx
+++ b/apps/playground/src/component/NativeNotificationConfig.tsx
@@ -33,10 +33,6 @@ export const NativeNotificationConfig = ({
         try {
             const newConfig = await openDrawer({
                 initialData: config,
-                bottomSheetProps: {
-                    snapPoints: ['80%'],
-                    enableDynamicSizing: false,
-                },
                 containerType: 'scrollview',
                 title: 'Native Notifications',
                 footerType: 'confirm_cancel',

--- a/packages/expo-audio-stream/src/ExpoAudioStream.types.ts
+++ b/packages/expo-audio-stream/src/ExpoAudioStream.types.ts
@@ -189,6 +189,10 @@ export interface RecordingConfig {
 
     // Optional callback to handle recording interruptions
     onRecordingInterrupted?: (_: RecordingInterruptionEvent) => void
+
+    // Optional output configuration
+    outputDirectory?: string // If not provided, uses default app directory
+    filename?: string // If not provided, uses UUID
 }
 
 export interface NotificationConfig {

--- a/packages/expo-audio-stream/src/WebRecorder.web.ts
+++ b/packages/expo-audio-stream/src/WebRecorder.web.ts
@@ -351,6 +351,10 @@ export class WebRecorder {
             return { pcmData: new Float32Array() }
         } finally {
             this.cleanup()
+            // Reset the chunks array
+            this.compressedChunks = []
+            this.compressedSize = 0
+            this.pendingCompressedChunk = null
         }
     }
 


### PR DESCRIPTION
# Description
## Overview
This PR adds the ability to specify custom filenames and output directories for audio recordings across all platforms (iOS, Android, and Web). The implementation includes proper validation of paths, error handling, and consistent behavior across platforms.

## Key Changes
- Added `filename` and `outputDirectory` options to `RecordingConfig`
- Implemented custom filename support across all platforms (iOS, Android, Web)
- Added directory validation and error handling
- Improved file path handling and cleaning
- Added UI for custom filename input in the playground app
- Added storage location info display for native platforms

## Implementation Details
### Core Features
- **Custom Filename Support**: Users can now specify custom filenames for recordings
  - Automatically appends `.wav` extension if missing
  - Falls back to UUID/timestamp if no filename provided
  - Handles extension stripping and re-adding properly

### Platform-Specific Changes
#### iOS
- Added filename and directory validation in `RecordingSettings.swift`
- Updated `AudioStreamManager.swift` to handle custom paths
- Improved error handling for invalid directories

#### Android
- Added directory validation in `RecordingConfig.kt`
- Updated file creation logic in `AudioRecorderManager.kt`
- Improved path normalization and validation

#### Web
- Updated `ExpoAudioStream.web.ts` to support custom filenames
- Maintained consistent behavior with native platforms
- Added proper cleanup of recording resources

### UI Updates
- Added filename input field in recording screen
- Added storage location info display for native platforms
- Improved error messaging for storage-related issues

## Breaking Changes
None. All new features are opt-in through optional configuration parameters.

