### PR TITLE
feat(expo-audio-ui): Add DecibelGauge and DecibelMeter components

### DIFF
--- a/packages/expo-audio-ui/src/DecibelGauge/DecibelGauge.stories.tsx
+++ b/packages/expo-audio-ui/src/DecibelGauge/DecibelGauge.stories.tsx
@@ -156,7 +156,7 @@ export const MultipleRanges: Story = {
 
 // Simulated live audio levels
 export const LiveAudio: Story = {
-    render: () => {
+    render: function LiveAudioStory() {
         const [db, setDb] = React.useState(-60)
         const font = useFont(RobotoRegular, 14)
 
@@ -192,6 +192,72 @@ export const LiveAudio: Story = {
                                         size: 16,
                                     },
                                 }}
+                            />
+                        </Canvas>
+                    </View>
+                </View>
+            </View>
+        )
+    },
+}
+
+// Add a new story for different sizes
+export const DifferentSizes: Story = {
+    render: function DifferentSizesStory() {
+        const font = useFont(RobotoRegular, 14)
+
+        if (!font) return <ActivityIndicator />
+
+        return (
+            <View style={styles.container}>
+                <View style={styles.row}>
+                    <View style={styles.gauge}>
+                        <Text style={styles.label}>Small</Text>
+                        <Canvas style={{ width: 100, height: 60 }}>
+                            <DecibelGauge
+                                db={-30}
+                                theme={{
+                                    size: {
+                                        width: 100,
+                                        height: 60,
+                                        radius: 20,
+                                    },
+                                    strokeWidth: 8,
+                                }}
+                                font={font}
+                            />
+                        </Canvas>
+                    </View>
+                    <View style={styles.gauge}>
+                        <Text style={styles.label}>Medium</Text>
+                        <Canvas style={{ width: 200, height: 120 }}>
+                            <DecibelGauge
+                                db={-30}
+                                theme={{
+                                    size: {
+                                        width: 200,
+                                        height: 120,
+                                        radius: 40,
+                                    },
+                                }}
+                                font={font}
+                            />
+                        </Canvas>
+                    </View>
+                    <View style={styles.gauge}>
+                        <Text style={styles.label}>Large</Text>
+                        <Canvas style={{ width: 300, height: 180 }}>
+                            <DecibelGauge
+                                db={-30}
+                                theme={{
+                                    size: {
+                                        width: 300,
+                                        height: 180,
+                                        radius: 60,
+                                    },
+                                    strokeWidth: 15,
+                                }}
+                                font={font}
                             />
                         </Canvas>
                     </View>

--- a/packages/expo-audio-ui/src/DecibelGauge/DecibelGauge.stories.tsx
+++ b/packages/expo-audio-ui/src/DecibelGauge/DecibelGauge.stories.tsx
@@ -1,0 +1,115 @@
+import { Canvas } from '@shopify/react-native-skia'
+import type { Meta, StoryObj } from '@storybook/react'
+import React from 'react'
+import { View } from 'react-native'
+
+import { DecibelGauge } from './DecibelGauge'
+
+const styles = {
+    container: {
+        padding: 16,
+        backgroundColor: '#000',
+    },
+    gaugeWrapper: {
+        marginBottom: 16,
+    },
+}
+
+const DecibelGaugeStory = (args: React.ComponentProps<typeof DecibelGauge>) => (
+    <Canvas style={{ width: 200, height: 60 }}>
+        <DecibelGauge {...args} />
+    </Canvas>
+)
+
+const meta = {
+    title: 'Audio UI/DecibelGauge',
+    component: DecibelGaugeStory,
+    decorators: [
+        (Story) => (
+            <View style={styles.container}>
+                <Story />
+            </View>
+        ),
+    ],
+} satisfies Meta<typeof DecibelGauge>
+
+export default meta
+type Story = StoryObj<typeof DecibelGauge>
+
+// Basic usage - only needs db value
+export const Default: Story = {
+    args: {
+        db: -30,
+    },
+}
+
+// Custom theme example
+export const CustomTheme: Story = {
+    args: {
+        db: -20,
+        theme: {
+            colors: {
+                low: '#00FF00',
+                mid: '#FFFF00',
+                high: '#FF0000',
+            },
+            strokeWidth: 15,
+        },
+    },
+}
+
+// Multiple ranges example
+export const MultipleRanges: Story = {
+    render: () => (
+        <>
+            <View style={styles.gaugeWrapper}>
+                <Canvas style={{ width: 200, height: 60 }}>
+                    <DecibelGauge
+                        db={-50}
+                        theme={{
+                            minDb: -60,
+                            maxDb: -40,
+                            colors: {
+                                low: '#34C759',
+                                mid: '#34C759',
+                                high: '#34C759',
+                            },
+                        }}
+                    />
+                </Canvas>
+            </View>
+            <View style={styles.gaugeWrapper}>
+                <Canvas style={{ width: 200, height: 60 }}>
+                    <DecibelGauge
+                        db={-30}
+                        theme={{
+                            minDb: -40,
+                            maxDb: -20,
+                            colors: {
+                                low: '#FFD60A',
+                                mid: '#FFD60A',
+                                high: '#FFD60A',
+                            },
+                        }}
+                    />
+                </Canvas>
+            </View>
+            <View style={styles.gaugeWrapper}>
+                <Canvas style={{ width: 200, height: 60 }}>
+                    <DecibelGauge
+                        db={-10}
+                        theme={{
+                            minDb: -20,
+                            maxDb: 0,
+                            colors: {
+                                low: '#FF453A',
+                                mid: '#FF453A',
+                                high: '#FF453A',
+                            },
+                        }}
+                    />
+                </Canvas>
+            </View>
+        </>
+    ),
+}

--- a/packages/expo-audio-ui/src/DecibelGauge/DecibelGauge.stories.tsx
+++ b/packages/expo-audio-ui/src/DecibelGauge/DecibelGauge.stories.tsx
@@ -1,25 +1,65 @@
-import { Canvas } from '@shopify/react-native-skia'
+import { Canvas, useFont } from '@shopify/react-native-skia'
 import type { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
-import { View } from 'react-native'
+import {
+    ActivityIndicator,
+    StyleSheet,
+    Text,
+    TextStyle,
+    View,
+    ViewStyle,
+} from 'react-native'
 
 import { DecibelGauge } from './DecibelGauge'
 
-const styles = {
+// Import the font file
+const RobotoRegular = require('../../assets/Roboto/Roboto-Regular.ttf')
+
+interface Styles {
+    container: ViewStyle
+    gaugeWrapper: ViewStyle
+    row: ViewStyle
+    gauge: ViewStyle
+    label: TextStyle
+}
+
+const styles = StyleSheet.create<Styles>({
     container: {
-        padding: 16,
-        backgroundColor: '#000',
+        flex: 1,
+        padding: 20,
+        backgroundColor: '#1C1C1E',
     },
     gaugeWrapper: {
         marginBottom: 16,
     },
-}
+    row: {
+        flexDirection: 'row' as const,
+        justifyContent: 'space-around' as const,
+        width: '100%',
+    },
+    gauge: {
+        alignItems: 'center' as const,
+    },
+    label: {
+        color: '#FFFFFF',
+        marginBottom: 10,
+        fontSize: 16,
+    },
+})
 
-const DecibelGaugeStory = (args: React.ComponentProps<typeof DecibelGauge>) => (
-    <Canvas style={{ width: 200, height: 60 }}>
-        <DecibelGauge {...args} />
-    </Canvas>
-)
+const DecibelGaugeStory = (args: React.ComponentProps<typeof DecibelGauge>) => {
+    const font = useFont(RobotoRegular, 14)
+
+    if (!font) {
+        return null
+    }
+
+    return (
+        <Canvas style={{ width: 200, height: 60 }}>
+            <DecibelGauge {...args} font={font} />
+        </Canvas>
+    )
+}
 
 const meta = {
     title: 'Audio UI/DecibelGauge',
@@ -112,4 +152,51 @@ export const MultipleRanges: Story = {
             </View>
         </>
     ),
+}
+
+// Simulated live audio levels
+export const LiveAudio: Story = {
+    render: () => {
+        const [db, setDb] = React.useState(-60)
+        const font = useFont(RobotoRegular, 14)
+
+        React.useEffect(() => {
+            const interval = setInterval(() => {
+                const randomDb = Math.sin(Date.now() / 1000) * 30 - 30
+                setDb(randomDb)
+            }, 100)
+            return () => clearInterval(interval)
+        }, [])
+
+        if (!font) return <ActivityIndicator />
+
+        return (
+            <View style={styles.container}>
+                <View style={styles.row}>
+                    <View style={styles.gauge}>
+                        <Text style={styles.label}>Without Value</Text>
+                        <Canvas style={{ width: 200, height: 60 }}>
+                            <DecibelGauge db={db} font={font} />
+                        </Canvas>
+                    </View>
+                    <View style={styles.gauge}>
+                        <Text style={styles.label}>With Value</Text>
+                        <Canvas style={{ width: 200, height: 60 }}>
+                            <DecibelGauge
+                                db={db}
+                                showValue
+                                font={font}
+                                theme={{
+                                    text: {
+                                        color: '#FFFFFF',
+                                        size: 16,
+                                    },
+                                }}
+                            />
+                        </Canvas>
+                    </View>
+                </View>
+            </View>
+        )
+    },
 }

--- a/packages/expo-audio-ui/src/DecibelGauge/DecibelGauge.tsx
+++ b/packages/expo-audio-ui/src/DecibelGauge/DecibelGauge.tsx
@@ -1,0 +1,93 @@
+import { Path } from '@shopify/react-native-skia'
+import React, { useEffect, useMemo } from 'react'
+import {
+    useDerivedValue,
+    useSharedValue,
+    withSpring,
+} from 'react-native-reanimated'
+
+interface DecibelGaugeTheme {
+    minDb?: number
+    maxDb?: number
+    backgroundColor?: string
+    strokeWidth?: number
+    colors: {
+        low: string
+        mid: string
+        high: string
+    }
+}
+
+const DEFAULT_THEME: DecibelGaugeTheme = {
+    minDb: -60,
+    maxDb: 0,
+    backgroundColor: '#333333',
+    strokeWidth: 10,
+    colors: {
+        low: '#34C759',
+        mid: '#FFD60A',
+        high: '#FF453A',
+    },
+}
+
+interface DecibelGaugeProps {
+    db: number
+    theme?: Partial<DecibelGaugeTheme>
+}
+
+export function DecibelGauge({ db, theme }: DecibelGaugeProps) {
+    const mergedTheme = { ...DEFAULT_THEME, ...theme }
+    const { minDb, maxDb } = mergedTheme
+
+    const animatedDb = useSharedValue(minDb)
+    const animatedProgress = useDerivedValue(() => {
+        const normalizedValue = Math.max(
+            minDb,
+            Math.min(maxDb, animatedDb.value)
+        )
+        return (normalizedValue - minDb) / (maxDb - minDb)
+    })
+
+    useEffect(() => {
+        animatedDb.value = withSpring(db)
+    }, [db])
+
+    const gradientPath = useMemo(() => {
+        const radius = 30
+        const centerX = 100
+        const centerY = 60
+        const startX = centerX - radius
+        const endX = centerX + radius
+
+        return `M ${startX} ${centerY} A ${radius} ${radius} 0 0 1 ${endX} ${centerY}`
+    }, [])
+
+    const getColor = (value: number) => {
+        if (value <= 0.6) return mergedTheme.colors.low
+        if (value <= 0.8) return mergedTheme.colors.mid
+        return mergedTheme.colors.high
+    }
+
+    const animatedColor = useDerivedValue(() => {
+        return getColor(animatedProgress.value)
+    })
+
+    return (
+        <>
+            <Path
+                path={gradientPath}
+                strokeWidth={mergedTheme.strokeWidth}
+                style="stroke"
+                color={mergedTheme.backgroundColor}
+            />
+            <Path
+                path={gradientPath}
+                strokeWidth={mergedTheme.strokeWidth}
+                style="stroke"
+                color={animatedColor}
+                start={0}
+                end={animatedProgress}
+            />
+        </>
+    )
+}

--- a/packages/expo-audio-ui/src/DecibelMeter/DecibelMeter.stories.tsx
+++ b/packages/expo-audio-ui/src/DecibelMeter/DecibelMeter.stories.tsx
@@ -1,0 +1,172 @@
+import { Canvas, useFont } from '@shopify/react-native-skia'
+import type { Meta, StoryObj } from '@storybook/react'
+import React from 'react'
+import { ActivityIndicator, StyleSheet, View } from 'react-native'
+
+import { DecibelMeter } from './DecibelMeter'
+
+const RobotoRegular = require('../../assets/Roboto/Roboto-Regular.ttf')
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        padding: 20,
+        backgroundColor: '#1C1C1E',
+    },
+    canvas: {
+        flex: 1,
+    },
+    wrapper: {
+        overflow: 'hidden',
+    },
+})
+
+interface DecibelMeterStoryProps
+    extends React.ComponentProps<typeof DecibelMeter> {
+    width: number
+    height: number
+}
+
+const DecibelMeterStory = ({
+    width,
+    height,
+    ...props
+}: DecibelMeterStoryProps) => {
+    const font = useFont(RobotoRegular, 10)
+
+    if (!font) {
+        return <ActivityIndicator />
+    }
+
+    return (
+        <View style={[styles.wrapper, { width, height }]}>
+            <Canvas style={styles.canvas}>
+                <DecibelMeter
+                    {...props}
+                    width={width}
+                    height={height}
+                    font={font}
+                />
+            </Canvas>
+        </View>
+    )
+}
+
+const meta = {
+    title: 'Audio UI/DecibelMeter',
+    component: DecibelMeterStory,
+    decorators: [
+        (Story) => (
+            <View style={styles.container}>
+                <Story />
+            </View>
+        ),
+    ],
+} satisfies Meta<typeof DecibelMeter>
+
+export default meta
+type Story = StoryObj<typeof DecibelMeter>
+
+export const VerticalMeter: Story = {
+    args: {
+        db: -30,
+        width: 100,
+        height: 300,
+        orientation: 'vertical',
+        minDb: -60,
+        maxDb: 0,
+    },
+}
+
+export const HorizontalMeter: Story = {
+    args: {
+        db: -30,
+        width: 300,
+        height: 100,
+        orientation: 'horizontal',
+        minDb: -60,
+        maxDb: 0,
+    },
+}
+
+export const CustomTheme: Story = {
+    args: {
+        db: -30,
+        width: 100,
+        height: 300,
+        orientation: 'vertical',
+        minDb: -60,
+        maxDb: 0,
+        theme: {
+            backgroundColor: '#2C2C2E',
+            meterWidth: 30,
+            colors: {
+                low: '#4CAF50',
+                mid: '#FFC107',
+                high: '#F44336',
+            },
+            ruler: {
+                show: true,
+                tickColor: '#FFFFFF',
+                labelColor: '#FFFFFF',
+                tickHeight: 8,
+                labelFontSize: 12,
+                interval: 20,
+            },
+        },
+    },
+}
+
+export const AnimatedMeter: Story = {
+    render: function Render() {
+        const font = useFont(RobotoRegular, 10)
+        const [db, setDb] = React.useState(-60)
+
+        React.useEffect(() => {
+            const interval = setInterval(() => {
+                setDb((current) => {
+                    if (current >= -10) return -60
+                    return current + 5
+                })
+            }, 200)
+
+            return () => clearInterval(interval)
+        }, [])
+
+        if (!font) {
+            return <ActivityIndicator />
+        }
+
+        return (
+            <View style={[styles.wrapper, { width: 100, height: 300 }]}>
+                <Canvas style={styles.canvas}>
+                    <DecibelMeter
+                        db={db}
+                        width={100}
+                        height={300}
+                        orientation="vertical"
+                        minDb={-60}
+                        maxDb={0}
+                        font={font}
+                    />
+                </Canvas>
+            </View>
+        )
+    },
+}
+
+export const NoRuler: Story = {
+    args: {
+        db: -30,
+        width: 100,
+        height: 300,
+        orientation: 'vertical',
+        minDb: -60,
+        maxDb: 0,
+        theme: {
+            ruler: {
+                show: false,
+            },
+        },
+    },
+}

--- a/packages/expo-audio-ui/src/DecibelMeter/DecibelMeter.tsx
+++ b/packages/expo-audio-ui/src/DecibelMeter/DecibelMeter.tsx
@@ -1,0 +1,180 @@
+import { Line, Rect, SkFont, Text } from '@shopify/react-native-skia'
+import React, { useMemo } from 'react'
+
+import { DEFAULT_LABEL_COLOR, DEFAULT_TICK_COLOR, isWeb } from '../constants'
+
+interface DecibelMeterTheme {
+    backgroundColor?: string
+    meterWidth?: number
+    colors: {
+        low: string
+        mid: string
+        high: string
+    }
+    ruler?: {
+        show: boolean
+        tickColor?: string
+        labelColor?: string
+        tickHeight?: number
+        labelFontSize?: number
+        interval?: number // Interval for tick marks in dB
+    }
+}
+
+const DEFAULT_THEME: DecibelMeterTheme = {
+    backgroundColor: '#333333',
+    meterWidth: 20,
+    colors: {
+        low: '#34C759',
+        mid: '#FFD60A',
+        high: '#FF453A',
+    },
+    ruler: {
+        show: true,
+        tickColor: DEFAULT_TICK_COLOR,
+        labelColor: DEFAULT_LABEL_COLOR,
+        tickHeight: 5,
+        labelFontSize: 10,
+        interval: 10,
+    },
+}
+
+interface DecibelMeterProps {
+    db: number
+    width: number
+    height: number
+    minDb?: number
+    maxDb?: number
+    orientation?: 'vertical' | 'horizontal'
+    theme?: Partial<DecibelMeterTheme>
+    font?: SkFont
+}
+
+export function DecibelMeter({
+    db,
+    width,
+    height,
+    minDb = -60,
+    maxDb = 0,
+    orientation = 'vertical',
+    theme,
+    font,
+}: DecibelMeterProps) {
+    const mergedTheme = useMemo(() => ({ ...DEFAULT_THEME, ...theme }), [theme])
+
+    const getColor = (value: number) => {
+        if (value <= 0.6) return mergedTheme.colors.low
+        if (value <= 0.8) return mergedTheme.colors.mid
+        return mergedTheme.colors.high
+    }
+
+    const meterWidth = mergedTheme.meterWidth ?? DEFAULT_THEME.meterWidth ?? 20
+    const isVertical = orientation === 'vertical'
+
+    // Calculate fill height/width based on current db value directly
+    const currentProgress =
+        (Math.max(minDb, Math.min(maxDb, db)) - minDb) / (maxDb - minDb)
+    const fillSize = isVertical
+        ? height * currentProgress
+        : width * currentProgress
+
+    const renderRuler = () => {
+        if (!mergedTheme.ruler?.show || !font) return null
+
+        interface RulerConfig {
+            interval: number
+            tickHeight: number
+            labelFontSize: number
+            tickColor: string
+            labelColor: string
+        }
+
+        const rulerConfig: RulerConfig = {
+            interval:
+                mergedTheme.ruler?.interval ?? DEFAULT_THEME.ruler!.interval!,
+            tickHeight:
+                mergedTheme.ruler?.tickHeight ??
+                DEFAULT_THEME.ruler!.tickHeight!,
+            labelFontSize:
+                mergedTheme.ruler?.labelFontSize ??
+                DEFAULT_THEME.ruler!.labelFontSize!,
+            tickColor:
+                mergedTheme.ruler?.tickColor ?? DEFAULT_THEME.ruler!.tickColor!,
+            labelColor:
+                mergedTheme.ruler?.labelColor ??
+                DEFAULT_THEME.ruler!.labelColor!,
+        }
+
+        const numTicks = Math.floor((maxDb - minDb) / rulerConfig.interval) + 1
+        const isVertical = orientation === 'vertical'
+        const meterWidth =
+            mergedTheme.meterWidth ?? DEFAULT_THEME.meterWidth ?? 20
+        const spacing = isVertical
+            ? (height - meterWidth) / (numTicks - 1)
+            : (width - meterWidth) / (numTicks - 1)
+
+        return Array.from({ length: numTicks }).map((_, i) => {
+            const value = maxDb - i * rulerConfig.interval
+            const label = `${value}`
+            const labelWidth = !isWeb ? font.measureText(label).width : 20
+
+            const position = i * spacing
+            const tickStart = meterWidth
+            const { tickHeight, labelFontSize } = rulerConfig
+
+            return (
+                <React.Fragment key={i}>
+                    <Line
+                        p1={{
+                            x: isVertical ? tickStart : position,
+                            y: isVertical ? position : tickStart,
+                        }}
+                        p2={{
+                            x: isVertical ? tickStart + tickHeight : position,
+                            y: isVertical ? position : tickStart + tickHeight,
+                        }}
+                        color={rulerConfig.tickColor}
+                        strokeWidth={1}
+                    />
+                    <Text
+                        text={label}
+                        x={
+                            isVertical
+                                ? tickStart + tickHeight + 5
+                                : position - labelWidth / 2
+                        }
+                        y={
+                            isVertical
+                                ? position + labelFontSize / 3
+                                : tickStart + tickHeight + labelFontSize + 2
+                        }
+                        color={rulerConfig.labelColor}
+                        font={font}
+                    />
+                </React.Fragment>
+            )
+        })
+    }
+
+    return (
+        <>
+            {/* Background */}
+            <Rect
+                x={0}
+                y={0}
+                width={isVertical ? meterWidth : width}
+                height={isVertical ? height : meterWidth}
+                color={mergedTheme.backgroundColor}
+            />
+            {/* Fill */}
+            <Rect
+                x={0}
+                y={isVertical ? height - fillSize : 0}
+                width={isVertical ? meterWidth : fillSize}
+                height={isVertical ? fillSize : meterWidth}
+                color={getColor(currentProgress)}
+            />
+            {renderRuler()}
+        </>
+    )
+}


### PR DESCRIPTION
# Description
This PR introduces two new visualization components to the expo-audio-ui package: DecibelGauge and DecibelMeter. These components provide flexible and customizable ways to display audio decibel levels in React Native applications.

## Key Features

### DecibelGauge Component
- Circular gauge visualization for decibel levels
- Customizable theming including colors, sizes, and stroke widths
- Animated transitions between decibel values
- Optional value display
- Support for different size variants (small, medium, large)
- Built with @shopify/react-native-skia for smooth rendering

### DecibelMeter Component
- Linear meter visualization for decibel levels
- Supports both vertical and horizontal orientations
- Customizable ruler with tick marks and labels
- Color gradients based on decibel ranges
- Configurable min/max decibel ranges
- Themeable appearance

## Implementation Details
- Built using @shopify/react-native-skia for high-performance graphics
- Uses react-native-reanimated for smooth value transitions
- Components are fully typed with TypeScript
- Comprehensive Storybook stories for both components demonstrating various use cases
- Font handling with Roboto for consistent text rendering
- Cross-platform support with web-specific adjustments

## Breaking Changes
None. This PR only adds new components without modifying existing functionality.

