### PR TITLE
fix(ios): improve audio recording interruption handling and auto-resume functionality

### DIFF
--- a/packages/expo-audio-stream/ios/AudioStreamManager.swift
+++ b/packages/expo-audio-stream/ios/AudioStreamManager.swift
@@ -163,13 +163,13 @@ class AudioStreamManager: NSObject {
                         // Configure audio session
                         do {
                             let session = AVAudioSession.sharedInstance()
-                            try session.setActive(false, options: .notifyOthersOnDeactivation)
                             try session.setCategory(.playAndRecord, mode: .default, options: [.allowBluetooth, .mixWithOthers])
                             try session.setActive(true, options: .notifyOthersOnDeactivation)
                             
                             // Resume if we're still recording and paused
                             if self.isRecording && self.isPaused {
                                 Logger.debug("Resuming recording after phone call interruption")
+                                self.audioEngine.prepare() 
                                 self.resumeRecording()
                             } else {
                                 Logger.debug("Cannot resume - recording state invalid: isRecording=\(self.isRecording), isPaused=\(self.isPaused)")


### PR DESCRIPTION
# Description
This PR addresses several iOS-specific issues related to audio recording interruption handling and auto-resume functionality, fixing the following reported issues:
- #108: onRecordingInterrupted not triggered & autoResumeAfterInterruption not working after phone calls
- #111: durationMs not updating after manual resume following phone calls
- #107: Recording stops in background state

## Key Changes
1. Unified event handling system:
   - Consolidated multiple event types (`recordingStateChanged`, `notificationStateChanged`) into a single `onRecordingInterrupted` event
   - Standardized event payload format with `reason`, `isPaused`, and `timestamp` fields
   - Added specific interruption reasons: `audioFocusLoss`, `audioFocusGain`, `phoneCallEnded`, `userPaused`, `userResumed`, `notification`

2. Improved audio session handling:
   - Removed premature audio session deactivation before category change
   - Added `audioEngine.prepare()` call before resuming recording after interruption
   - Maintained proper audio session state through phone call interruptions

3. Enhanced interruption handling:
   - Added comprehensive interruption type detection and mapping
   - Improved phone call end detection with `wasSuspended` flag
   - Better state management during background transitions

## Breaking Changes
- Event payload structure has changed for recording state updates
- Removed separate `recordingStateChanged` and `notificationStateChanged` events in favor of unified `onRecordingInterrupted`

Related issues: #107, #108, #111