### PR TITLE
fix: restore Opus compression support on iOS

### DIFF
--- a/documentation_site/docs/api-reference/API/interfaces/RecordingConfig.md
+++ b/documentation_site/docs/api-reference/API/interfaces/RecordingConfig.md
@@ -52,7 +52,7 @@
 
 #### format
 
-> **format**: `"opus"` \| `"aac"` \| `"mp3"`
+> **format**: `"opus"` \| `"aac"`
 
 #### Defined in
 

--- a/packages/expo-audio-stream/src/ExpoAudioStream.types.ts
+++ b/packages/expo-audio-stream/src/ExpoAudioStream.types.ts
@@ -182,7 +182,7 @@ export interface RecordingConfig {
 
     compression?: {
         enabled: boolean
-        format: 'aac' | 'opus' | 'mp3'
+        format: 'aac' | 'opus'
         bitrate?: number
     }
 


### PR DESCRIPTION
# Description

This PR fixes an issue where Opus compression support was accidentally removed from iOS implementation. It also corrects documentation that incorrectly listed MP3 as a supported format.

## Changes Overview
- Restored Opus compression capability in iOS audio recording
- Corrected documentation to accurately reflect supported formats (AAC and Opus only)
- Added proper bit depth configuration for compressed recording

## Key Implementation Details
- Re-implemented Opus format support in `AudioStreamManager.swift`
- Updated compression settings to properly handle Opus format selection
- Added missing bit depth configuration in compressed recording settings
- Enhanced error handling for recorder initialization

## Bug Fixes
- Fixed iOS implementation to properly support Opus compression that was accidentally removed
- Corrected documentation that incorrectly listed MP3 as a supported format (MP3 was never actually supported due to format licensing restrictions)

## Documentation Updates
The `RecordingConfig` interface has been updated to accurately reflect the supported formats:
- Removed incorrect MP3 format option from documentation
- Clarified that only `'aac'` and `'opus'` formats are supported
