### PR TITLE
feat: add web permission for microphone

### DIFF
--- a/packages/expo-audio-stream/src/ExpoAudioStreamModule.ts
+++ b/packages/expo-audio-stream/src/ExpoAudioStreamModule.ts
@@ -42,13 +42,7 @@ if (Platform.OS === 'web') {
     ExpoAudioStreamModule.getPermissionsAsync = async () => {
         let maybeStatus: string | null = null
 
-        if (
-            !navigator ||
-            !navigator.permissions ||
-            !navigator.permissions.query
-        ) {
-            maybeStatus = null
-        } else {
+        if (navigator?.permissions?.query) {
             try {
                 const { state } = await navigator.permissions.query({
                     name: 'microphone' as PermissionName,


### PR DESCRIPTION
Implementation of the web permission for microphone. Based on expo-audio packages. Fix #130 