### PR TITLE
feat: Add Sample Rate Control and Web Trimming Support to Expo Audio Stream

### DIFF
--- a/apps/playground/src/components/TrimVisualization.tsx
+++ b/apps/playground/src/components/TrimVisualization.tsx
@@ -98,7 +98,9 @@ const TrimVisualization: React.FC<TrimVisualizationProps> = ({
             <Text variant="titleMedium" style={{ marginBottom: 8 }}>Trim Preview</Text>
             
             <View style={{ marginBottom: 16 }}>
-                <Text style={{ marginBottom: 4 }}>Original: {(durationMs / 1000).toFixed(1)}s</Text>
+                <Text style={{ marginBottom: 4 }}>
+                    {(durationMs / 1000).toFixed(1)}s → {(finalDuration / 1000).toFixed(1)}s ({percentageKept}% kept)
+                </Text>
                 <View style={{ height: 24, backgroundColor: colors.surfaceVariant, borderRadius: 4, overflow: 'hidden', flexDirection: 'row' }}>
                     {segments.map((isKept, index) => (
                         <View 
@@ -127,22 +129,6 @@ const TrimVisualization: React.FC<TrimVisualizationProps> = ({
                                 {marker.label}
                             </Text>
                         </View>
-                    ))}
-                </View>
-            </View>
-            
-            <View style={{ marginBottom: 8 }}>
-                <Text style={{ marginBottom: 4 }}>After Trim: {(finalDuration / 1000).toFixed(1)}s ({percentageKept}% kept)</Text>
-                <View style={{ height: 24, backgroundColor: colors.surfaceVariant, borderRadius: 4, overflow: 'hidden', flexDirection: 'row' }}>
-                    {segments.filter(isKept => isKept).map((_, index) => (
-                        <View 
-                            key={index} 
-                            style={{ 
-                                flex: 1, 
-                                height: '100%', 
-                                backgroundColor: colors.primary,
-                            }} 
-                        />
                     ))}
                 </View>
             </View>

--- a/packages/expo-audio-stream/src/ExpoAudioStream.types.ts
+++ b/packages/expo-audio-stream/src/ExpoAudioStream.types.ts
@@ -412,7 +412,7 @@ export interface TrimAudioOptions {
         /**
          * The format of the output audio file.
          * - `'wav'`: Waveform Audio File Format (uncompressed).
-         * - `'aac'`: Advanced Audio Coding (compressed).
+         * - `'aac'`: Advanced Audio Coding (compressed). Not supported on web platforms.
          * - `'opus'`: Opus Interactive Audio Codec (compressed).
          */
         format: 'wav' | 'aac' | 'opus'
@@ -512,7 +512,7 @@ export interface TrimAudioResult {
          */
         size: number
     }
-    
+
     /**
      * Information about the processing time.
      */

--- a/packages/expo-audio-stream/src/ExpoAudioStreamModule.ts
+++ b/packages/expo-audio-stream/src/ExpoAudioStreamModule.ts
@@ -6,6 +6,8 @@ import {
     ExtractAudioDataOptions,
     ExtractedAudioData,
     BitDepth,
+    TrimAudioOptions,
+    TrimAudioResult,
 } from './ExpoAudioStream.types'
 import {
     ExpoAudioStreamWeb,
@@ -279,7 +281,686 @@ if (Platform.OS === 'web') {
             throw error
         }
     }
-} else {
+
+    ExpoAudioStreamModule.trimAudio = async (
+        options: TrimAudioOptions
+    ): Promise<TrimAudioResult> => {
+        try {
+            const startTime = performance.now()
+            const {
+                fileUri,
+                mode = 'single',
+                startTimeMs,
+                endTimeMs,
+                ranges,
+                outputFileName,
+                outputFormat,
+            } = options
+
+            // Validate inputs
+            if (!fileUri) {
+                throw new Error('fileUri is required')
+            }
+
+            if (
+                mode === 'single' &&
+                startTimeMs === undefined &&
+                endTimeMs === undefined
+            ) {
+                throw new Error(
+                    'At least one of startTimeMs or endTimeMs must be provided in single mode'
+                )
+            }
+
+            if (
+                (mode === 'keep' || mode === 'remove') &&
+                (!ranges || ranges.length === 0)
+            ) {
+                throw new Error(
+                    'ranges must be provided and non-empty for keep or remove modes'
+                )
+            }
+
+            // Create AudioContext
+            const audioContext = new (window.AudioContext ||
+                (window as any).webkitAudioContext)()
+
+            // First, load the entire audio file to get its properties
+            const response = await fetch(fileUri)
+            const arrayBuffer = await response.arrayBuffer()
+            const originalAudioBuffer =
+                await audioContext.decodeAudioData(arrayBuffer)
+
+            // Get original audio properties
+            const originalSampleRate = originalAudioBuffer.sampleRate
+            const originalChannels = originalAudioBuffer.numberOfChannels
+
+            // Add more detailed logging
+            console.log(`Original audio details:`, {
+                sampleRate: originalSampleRate,
+                channels: originalChannels,
+                duration: originalAudioBuffer.duration,
+                length: originalAudioBuffer.length,
+                // Log a few samples to verify content
+                firstSamples: Array.from(
+                    originalAudioBuffer.getChannelData(0).slice(0, 5)
+                ),
+            })
+
+            // Determine output format - use original values as defaults if not specified
+            let format = outputFormat?.format || 'wav'
+            const targetSampleRate =
+                outputFormat?.sampleRate || originalSampleRate
+            const targetChannels = outputFormat?.channels || originalChannels
+            const targetBitDepth = outputFormat?.bitDepth || 16
+
+            // Get file info from the URL
+            const filename =
+                outputFileName ||
+                fileUri.split('/').pop() ||
+                'trimmed-audio.wav'
+
+            // Process based on mode
+            let resultBuffer: AudioBuffer
+
+            // Report initial progress
+            ExpoAudioStreamModule.sendEvent('TrimProgress', {
+                progress: 10,
+            })
+
+            if (mode === 'single') {
+                // Single mode: extract a single range
+                // Use original sample rate and channels for extraction to preserve quality
+                const { buffer } = await processAudioBuffer({
+                    fileUri,
+                    targetSampleRate, // Use the requested sample rate
+                    targetChannels,
+                    normalizeAudio: false,
+                    startTimeMs,
+                    endTimeMs,
+                    audioContext,
+                })
+
+                console.log(`Processed buffer details:`, {
+                    sampleRate: buffer.sampleRate,
+                    channels: buffer.numberOfChannels,
+                    duration: buffer.duration,
+                    length: buffer.length,
+                    // Log a few samples to verify content
+                    firstSamples: Array.from(
+                        buffer.getChannelData(0).slice(0, 5)
+                    ),
+                })
+
+                resultBuffer = buffer
+
+                // If we need to change sample rate or channels, do it after extraction
+                if (
+                    targetSampleRate !== originalSampleRate ||
+                    targetChannels !== originalChannels
+                ) {
+                    console.log(
+                        `Resampling from ${originalSampleRate}Hz to ${targetSampleRate}Hz`
+                    )
+                    resultBuffer = await resampleAudioBuffer(
+                        audioContext,
+                        buffer,
+                        targetSampleRate,
+                        targetChannels
+                    )
+                }
+            } else {
+                // For keep or remove modes
+                const fullDuration = originalAudioBuffer.duration * 1000 // in ms
+
+                type ProcessSegment = {
+                    startTimeMs: number
+                    endTimeMs: number
+                }
+
+                let segmentsToProcess: ProcessSegment[] = []
+
+                if (mode === 'keep') {
+                    // For keep mode, use the ranges directly
+                    segmentsToProcess = ranges!
+                } else {
+                    // mode === 'remove'
+                    // For remove mode, invert the ranges
+                    const sortedRanges = [...ranges!].sort(
+                        (a, b) => a.startTimeMs - b.startTimeMs
+                    )
+
+                    // Add segment from start to first range if needed
+                    if (
+                        sortedRanges.length > 0 &&
+                        sortedRanges[0].startTimeMs > 0
+                    ) {
+                        segmentsToProcess.push({
+                            startTimeMs: 0,
+                            endTimeMs: sortedRanges[0].startTimeMs,
+                        })
+                    }
+
+                    // Add segments between ranges
+                    for (let i = 0; i < sortedRanges.length - 1; i++) {
+                        segmentsToProcess.push({
+                            startTimeMs: sortedRanges[i].endTimeMs,
+                            endTimeMs: sortedRanges[i + 1].startTimeMs,
+                        })
+                    }
+
+                    // Add segment from last range to end if needed
+                    if (
+                        sortedRanges.length > 0 &&
+                        sortedRanges[sortedRanges.length - 1].endTimeMs <
+                            fullDuration
+                    ) {
+                        segmentsToProcess.push({
+                            startTimeMs:
+                                sortedRanges[sortedRanges.length - 1].endTimeMs,
+                            endTimeMs: fullDuration,
+                        })
+                    }
+                }
+
+                // Filter out empty or invalid segments
+                segmentsToProcess = segmentsToProcess.filter(
+                    (segment) =>
+                        segment.startTimeMs < segment.endTimeMs &&
+                        segment.endTimeMs - segment.startTimeMs > 1
+                ) // 1ms minimum
+
+                if (segmentsToProcess.length === 0) {
+                    throw new Error(
+                        'No valid segments to process after filtering ranges'
+                    )
+                }
+
+                // Process each segment using original sample rate and channels
+                const segmentBuffers: AudioBuffer[] = []
+
+                for (let i = 0; i < segmentsToProcess.length; i++) {
+                    const segment = segmentsToProcess[i]
+
+                    // Report progress for each segment
+                    ExpoAudioStreamModule.sendEvent('TrimProgress', {
+                        progress:
+                            10 +
+                            Math.round((i / segmentsToProcess.length) * 40),
+                    })
+
+                    // Use processAudioBuffer to extract this segment
+                    const { buffer: segmentBuffer } = await processAudioBuffer({
+                        fileUri,
+                        targetSampleRate: originalSampleRate, // Use original sample rate
+                        targetChannels: originalChannels, // Use original channels
+                        normalizeAudio: false,
+                        startTimeMs: segment.startTimeMs,
+                        endTimeMs: segment.endTimeMs,
+                        audioContext,
+                    })
+
+                    segmentBuffers.push(segmentBuffer)
+                }
+
+                // Concatenate all segments
+                const totalSamples = segmentBuffers.reduce(
+                    (sum, buffer) => sum + buffer.length,
+                    0
+                )
+
+                // Create buffer with original properties first
+                const concatenatedBuffer = audioContext.createBuffer(
+                    originalChannels,
+                    totalSamples,
+                    originalSampleRate
+                )
+
+                let offset = 0
+                for (const segmentBuffer of segmentBuffers) {
+                    for (
+                        let channel = 0;
+                        channel < originalChannels;
+                        channel++
+                    ) {
+                        const outputData =
+                            concatenatedBuffer.getChannelData(channel)
+                        const segmentData =
+                            segmentBuffer.getChannelData(channel)
+
+                        for (let i = 0; i < segmentBuffer.length; i++) {
+                            outputData[offset + i] = segmentData[i]
+                        }
+                    }
+                    offset += segmentBuffer.length
+                }
+
+                resultBuffer = concatenatedBuffer
+
+                // If we need to change sample rate or channels, do it after concatenation
+                if (
+                    targetSampleRate !== originalSampleRate ||
+                    targetChannels !== originalChannels
+                ) {
+                    console.log(
+                        `Resampling concatenated buffer from ${originalSampleRate}Hz to ${targetSampleRate}Hz`
+                    )
+                    resultBuffer = await resampleAudioBuffer(
+                        audioContext,
+                        concatenatedBuffer,
+                        targetSampleRate,
+                        targetChannels
+                    )
+                }
+            }
+
+            // Report progress (50% - processing complete)
+            ExpoAudioStreamModule.sendEvent('TrimProgress', {
+                progress: 50,
+            })
+
+            // Encode the result based on the requested format
+            let outputData: ArrayBuffer
+            let outputMimeType: string
+            let compressionInfo: any = null
+
+            // Check if AAC was requested on web and show a warning
+            if (format === 'aac' && Platform.OS === 'web') {
+                console.warn(
+                    'AAC format is not supported on web platforms. Falling back to OPUS format.'
+                )
+                format = 'opus'
+            }
+
+            if (format === 'wav') {
+                // Create a properly interleaved buffer for WAV format
+                // For WAV, we need to convert Float32Array to Int16Array (for 16-bit audio)
+                const numSamples =
+                    resultBuffer.length * resultBuffer.numberOfChannels
+                const interleavedData = new Int16Array(numSamples)
+
+                // Log detailed information about the buffer before encoding
+                console.log(`Creating WAV file:`, {
+                    bufferSampleRate: resultBuffer.sampleRate,
+                    bufferChannels: resultBuffer.numberOfChannels,
+                    bufferLength: resultBuffer.length,
+                    targetSampleRate,
+                    targetChannels,
+                    targetBitDepth,
+                    // Log a few samples to verify content
+                    firstSamples: Array.from(
+                        resultBuffer.getChannelData(0).slice(0, 5)
+                    ),
+                })
+
+                // Interleave channels properly
+                for (let i = 0; i < resultBuffer.length; i++) {
+                    for (
+                        let channel = 0;
+                        channel < resultBuffer.numberOfChannels;
+                        channel++
+                    ) {
+                        // Convert float (-1.0 to 1.0) to int16 (-32768 to 32767)
+                        const floatSample =
+                            resultBuffer.getChannelData(channel)[i]
+                        // Clamp the value to -1.0 to 1.0
+                        const clampedSample = Math.max(
+                            -1.0,
+                            Math.min(1.0, floatSample)
+                        )
+                        // Convert to int16
+                        const intSample = Math.round(clampedSample * 32767)
+                        // Store in interleaved buffer
+                        interleavedData[
+                            i * resultBuffer.numberOfChannels + channel
+                        ] = intSample
+                    }
+                }
+
+                // Convert Int16Array to ArrayBuffer for WAV header
+                const rawBuffer = interleavedData.buffer
+
+                // IMPORTANT: Make sure we're using the ACTUAL sample rate of the buffer
+                // not just what was requested in the options
+                console.log(
+                    `Creating WAV with ${resultBuffer.numberOfChannels} channels at ${resultBuffer.sampleRate}Hz`
+                )
+
+                outputData = writeWavHeader({
+                    buffer: rawBuffer as ArrayBuffer,
+                    sampleRate: resultBuffer.sampleRate, // Use the actual buffer's sample rate
+                    numChannels: resultBuffer.numberOfChannels,
+                    bitDepth: targetBitDepth as BitDepth,
+                })
+                outputMimeType = 'audio/wav'
+            } else if (format === 'opus' || format === 'aac') {
+                try {
+                    // Try to use MediaRecorder for compressed formats
+                    const { data, bitrate } = await encodeCompressedAudio(
+                        resultBuffer,
+                        format,
+                        outputFormat?.bitrate
+                    )
+
+                    outputData = data
+                    outputMimeType =
+                        format === 'opus' ? 'audio/webm' : 'audio/aac'
+                    compressionInfo = {
+                        format,
+                        bitrate,
+                        size: data.byteLength,
+                    }
+                } catch (error) {
+                    console.warn(
+                        `Failed to encode to ${format}, falling back to WAV: ${error}`
+                    )
+
+                    // Same WAV encoding as above
+                    const wavData = new Float32Array(
+                        resultBuffer.length * resultBuffer.numberOfChannels
+                    )
+
+                    for (let i = 0; i < resultBuffer.length; i++) {
+                        for (
+                            let channel = 0;
+                            channel < resultBuffer.numberOfChannels;
+                            channel++
+                        ) {
+                            wavData[
+                                i * resultBuffer.numberOfChannels + channel
+                            ] = resultBuffer.getChannelData(channel)[i]
+                        }
+                    }
+
+                    outputData = writeWavHeader({
+                        buffer: wavData.buffer as ArrayBuffer,
+                        sampleRate: resultBuffer.sampleRate,
+                        numChannels: resultBuffer.numberOfChannels,
+                        bitDepth: targetBitDepth as BitDepth,
+                    })
+                    outputMimeType = 'audio/wav'
+                }
+            } else {
+                // Default to WAV for unsupported formats
+                console.warn(
+                    `Format ${format} not supported on web, using WAV instead`
+                )
+
+                // Same WAV encoding as above
+                const wavData = new Float32Array(
+                    resultBuffer.length * resultBuffer.numberOfChannels
+                )
+
+                for (let i = 0; i < resultBuffer.length; i++) {
+                    for (
+                        let channel = 0;
+                        channel < resultBuffer.numberOfChannels;
+                        channel++
+                    ) {
+                        wavData[i * resultBuffer.numberOfChannels + channel] =
+                            resultBuffer.getChannelData(channel)[i]
+                    }
+                }
+
+                outputData = writeWavHeader({
+                    buffer: wavData.buffer as ArrayBuffer,
+                    sampleRate: resultBuffer.sampleRate,
+                    numChannels: resultBuffer.numberOfChannels,
+                    bitDepth: targetBitDepth as BitDepth,
+                })
+                outputMimeType = 'audio/wav'
+            }
+
+            // Report progress (90% - encoding complete)
+            ExpoAudioStreamModule.sendEvent('TrimProgress', {
+                progress: 90,
+            })
+
+            // Create a blob and URL for the result
+            const blob = new Blob([outputData], { type: outputMimeType })
+            const outputUri = URL.createObjectURL(blob)
+
+            // Calculate processing time
+            const processingTimeMs = performance.now() - startTime
+
+            // Report progress (100% - complete)
+            ExpoAudioStreamModule.sendEvent('TrimProgress', {
+                progress: 100,
+            })
+
+            // Create result object
+            const result: TrimAudioResult = {
+                uri: outputUri,
+                filename,
+                durationMs: Math.round(resultBuffer.duration * 1000),
+                size: outputData.byteLength,
+                sampleRate: resultBuffer.sampleRate,
+                channels: resultBuffer.numberOfChannels,
+                bitDepth: targetBitDepth,
+                mimeType: outputMimeType,
+                processingInfo: {
+                    durationMs: processingTimeMs,
+                },
+            }
+
+            // Add compression info if available
+            if (compressionInfo) {
+                result.compression = compressionInfo
+            }
+
+            return result
+        } catch (error) {
+            console.error('Error in trimAudio:', error)
+            throw error
+        }
+    }
+
+    // Add a sendEvent method for web
+    ExpoAudioStreamModule.sendEvent = (eventName: string, params: any) => {
+        // This will be picked up by the LegacyEventEmitter in trimAudio.ts
+        if (
+            ExpoAudioStreamModule.listeners &&
+            ExpoAudioStreamModule.listeners[eventName]
+        ) {
+            ExpoAudioStreamModule.listeners[eventName].forEach(
+                (listener: Function) => {
+                    listener(params)
+                }
+            )
+        }
+    }
+
+    // Initialize listeners object
+    ExpoAudioStreamModule.listeners = {}
+
+    // Add methods for event listeners that LegacyEventEmitter will use
+    ExpoAudioStreamModule.addListener = (
+        eventName: string,
+        listener: Function
+    ) => {
+        if (!ExpoAudioStreamModule.listeners[eventName]) {
+            ExpoAudioStreamModule.listeners[eventName] = []
+        }
+        ExpoAudioStreamModule.listeners[eventName].push(listener)
+
+        // Return an object with a remove method
+        return {
+            remove: () => {
+                const index =
+                    ExpoAudioStreamModule.listeners[eventName].indexOf(listener)
+                if (index !== -1) {
+                    ExpoAudioStreamModule.listeners[eventName].splice(index, 1)
+                }
+            },
+        }
+    }
+
+    ExpoAudioStreamModule.removeAllListeners = (eventName: string) => {
+        if (ExpoAudioStreamModule.listeners[eventName]) {
+            delete ExpoAudioStreamModule.listeners[eventName]
+        }
+    }
+}
+
+// Move the encodeCompressedAudio function outside the if block to fix the ESLint error
+async function encodeCompressedAudio(
+    buffer: AudioBuffer,
+    format: 'opus' | 'aac',
+    bitrate?: number
+): Promise<{ data: ArrayBuffer; bitrate: number }> {
+    return new Promise((resolve, reject) => {
+        try {
+            // On web, always use opus if aac is requested
+            const actualFormat =
+                Platform.OS === 'web' && format === 'aac' ? 'opus' : format
+
+            // Check if MediaRecorder supports the requested format
+            const mimeType =
+                actualFormat === 'opus' ? 'audio/webm;codecs=opus' : 'audio/aac'
+            if (!MediaRecorder.isTypeSupported(mimeType)) {
+                throw new Error(`MediaRecorder does not support ${mimeType}`)
+            }
+
+            // Create a new AudioContext and source
+            const ctx = new (window.AudioContext ||
+                (window as any).webkitAudioContext)()
+            const source = ctx.createBufferSource()
+            source.buffer = buffer
+
+            // Create a MediaStreamDestination to capture the audio
+            const destination = ctx.createMediaStreamDestination()
+            source.connect(destination)
+
+            // Create a MediaRecorder with the requested format
+            const recorder = new MediaRecorder(destination.stream, {
+                mimeType,
+                audioBitsPerSecond:
+                    bitrate || (actualFormat === 'opus' ? 32000 : 64000),
+            })
+
+            const chunks: Blob[] = []
+
+            recorder.ondataavailable = (e) => {
+                if (e.data.size > 0) {
+                    chunks.push(e.data)
+                }
+            }
+
+            recorder.onstop = async () => {
+                try {
+                    const blob = new Blob(chunks, { type: mimeType })
+                    const arrayBuffer = await blob.arrayBuffer()
+
+                    // Get the actual bitrate used
+                    const actualBitrate = Math.round(
+                        (arrayBuffer.byteLength * 8) / buffer.duration
+                    )
+
+                    resolve({
+                        data: arrayBuffer,
+                        bitrate: actualBitrate / 1000, // Convert to kbps
+                    })
+
+                    // Clean up
+                    ctx.close()
+                } catch (error) {
+                    reject(error)
+                }
+            }
+
+            // Start recording and playback
+            recorder.start()
+            source.start(0)
+
+            // Stop recording when the buffer finishes playing
+            setTimeout(() => {
+                recorder.stop()
+                source.stop()
+            }, buffer.duration * 1000)
+        } catch (error) {
+            reject(error)
+        }
+    })
+}
+
+// Improved resampleAudioBuffer function
+async function resampleAudioBuffer(
+    context: AudioContext,
+    buffer: AudioBuffer,
+    targetSampleRate: number,
+    targetChannels: number
+): Promise<AudioBuffer> {
+    // If no change needed, return the original buffer
+    if (
+        buffer.sampleRate === targetSampleRate &&
+        buffer.numberOfChannels === targetChannels
+    ) {
+        return buffer
+    }
+
+    console.log(
+        `Resampling: ${buffer.sampleRate}Hz → ${targetSampleRate}Hz, ${buffer.numberOfChannels} → ${targetChannels} channels`
+    )
+
+    // Calculate the new length based on the sample rate change
+    const newLength = Math.round(
+        (buffer.length * targetSampleRate) / buffer.sampleRate
+    )
+
+    // Create an offline context for resampling
+    const offlineContext = new OfflineAudioContext(
+        targetChannels,
+        newLength,
+        targetSampleRate
+    )
+
+    // Create a source node
+    const source = offlineContext.createBufferSource()
+    source.buffer = buffer
+
+    // If we need to change channel count
+    if (buffer.numberOfChannels !== targetChannels) {
+        if (targetChannels === 1 && buffer.numberOfChannels > 1) {
+            // Downmix to mono
+            const merger = offlineContext.createChannelMerger(1)
+
+            // Create a gain node to reduce volume when downmixing to prevent clipping
+            const gainNode = offlineContext.createGain()
+            gainNode.gain.value = 1.0 / buffer.numberOfChannels
+
+            source.connect(gainNode)
+            gainNode.connect(merger)
+            merger.connect(offlineContext.destination)
+        } else if (targetChannels === 2 && buffer.numberOfChannels === 1) {
+            // Upmix mono to stereo (duplicate the channel)
+            const splitter = offlineContext.createChannelSplitter(1)
+            const merger = offlineContext.createChannelMerger(2)
+
+            source.connect(splitter)
+            splitter.connect(merger, 0, 0)
+            splitter.connect(merger, 0, 1)
+            merger.connect(offlineContext.destination)
+        } else {
+            // For other cases, just connect and let the system handle it
+            source.connect(offlineContext.destination)
+        }
+    } else {
+        // No channel conversion needed
+        source.connect(offlineContext.destination)
+    }
+
+    // Start rendering
+    source.start(0)
+    const resampledBuffer = await offlineContext.startRendering()
+
+    console.log(
+        `Resampling complete: ${resampledBuffer.length} samples at ${resampledBuffer.sampleRate}Hz`
+    )
+
+    return resampledBuffer
+}
+
+if (Platform.OS !== 'web') {
     ExpoAudioStreamModule = requireNativeModule('ExpoAudioStream')
 }
 

--- a/packages/expo-audio-stream/src/trimAudio.ts
+++ b/packages/expo-audio-stream/src/trimAudio.ts
@@ -15,7 +15,7 @@ const emitter = new LegacyEventEmitter(ExpoAudioStreamModule)
  * Trims an audio file based on the provided options.
  *
  * @experimental This API is experimental and not fully optimized for production use.
- * Currently only available on Android. Performance may vary based on file size and
+ * Currently only available on Android and Web. Performance may vary based on file size and
  * device capabilities. Future versions may include breaking changes.
  *
  * @param options Configuration options for the trimming operation
@@ -26,12 +26,8 @@ export async function trimAudio(
     options: TrimAudioOptions,
     progressCallback?: (event: TrimProgressEvent) => void
 ): Promise<TrimAudioResult> {
-    if (Platform.OS === 'web') {
-        throw new Error('trimAudio is not supported on web yet')
-    }
-
     if (Platform.OS === 'ios') {
-        throw new Error('trimAudio is currently only supported on Android')
+        throw new Error('trimAudio is currently only supported on Android and Web')
     }
 
     // Validation
@@ -85,7 +81,7 @@ export async function trimAudio(
  * Simplified version of trimAudio that returns only the URI of the trimmed file.
  *
  * @experimental This API is experimental and not fully optimized for production use.
- * Currently only available on Android. Performance may vary based on file size and
+ * Currently only available on Android and Web. Performance may vary based on file size and
  * device capabilities. Future versions may include breaking changes.
  *
  * @param options Configuration options for the trimming operation


### PR DESCRIPTION
# Description

## Purpose and Impact
This pull request introduces significant enhancements to the `@siteed/expo-audio-stream` package and its playground app by:
1. Adding customizable output sample rate control (16kHz, 44.1kHz, 48kHz) for audio trimming
2. Implementing full audio trimming support on web platforms
3. Improving the trimming visualization UI
4. Enhancing format compatibility handling with better web-specific considerations

These changes improve audio processing flexibility, extend platform support, and provide a better user experience for developers working with audio trimming features.

## Key Implementation Details

### Sample Rate Control
- Added `SampleRate` type and integrated it into `TrimAudioOptions.outputFormat`
- Implemented UI controls in `TrimScreen` with a segmented button for sample rate selection (16kHz, 44.1kHz, 48kHz)
- Updated trimming logic to respect the selected sample rate during processing

### Web Platform Trimming
- Implemented `trimAudio` functionality for web in `ExpoAudioStreamModule.ts`
- Added comprehensive web audio processing:
  - AudioContext-based buffer manipulation
  - Support for WAV and OPUS output formats
  - Fallback to OPUS when AAC is selected on web (with warning)
  - Progress event emission during processing
- Added resampling capabilities to handle sample rate and channel conversions

### UI Improvements
- Enhanced `TrimVisualization` component to show both original and trimmed duration with percentage kept
- Added platform-specific warnings (e.g., AAC not supported on web)
- Improved layout and controls in `trim.tsx`

### Format Handling
- Updated type definitions to document AAC limitations on web
- Added runtime checks and fallbacks for unsupported formats on web

## Breaking Changes
None identified. The changes are additive and maintain backward compatibility with existing API usage:
- Default sample rate remains 16kHz if not specified
- Existing trimming behavior remains unchanged when using default settings

## Migration Steps
No migration is required for existing users. To take advantage of new features:
1. Update `@siteed/expo-audio-stream` to this version
2. Optionally specify `outputFormat.sampleRate` in `TrimAudioOptions` for custom sample rates
3. Note that AAC is not supported on web and will fallback to OPUS

## Testing Instructions
1. **Playground App Testing**:
   - Run `apps/playground` on both native (Android) and web platforms
   - Test trimming with different:
     - Output formats (WAV, AAC, OPUS)
     - Sample rates (16kHz, 44.1kHz, 48kHz)
     - Trim modes (single, keep, remove)
   - Verify UI updates correctly showing original vs trimmed duration
   - Check web platform shows warning for AAC selection

2. **Package Testing**:
   - Use `trimAudio` API directly with various options
   - Verify output files match selected sample rate and format
   - Test web-specific behavior with invalid formats

3. **Special Considerations**:
   - On web, verify AAC selection falls back to OPUS with a console warning
   - Ensure progress events are emitted during web trimming
   - Test with large audio files to verify performance

## Additional Notes
- The web implementation uses AudioContext and MediaRecorder, which may have browser compatibility variations
- Performance on web may vary based on file size and browser capabilities
- Future improvements could include iOS support and additional format options