### PR TITLE
fix(audio-stream): resolve iOS sample rate mismatch and enhance recording stability

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -28,6 +28,8 @@
         "e2e:ios:record": "detox test -c ios.sim.debug -o e2e/record.test.ts",
         "e2e:ios:screenshots": "detox test -c ios.sim.debug -o e2e/screenshots.test.ts",
         "e2e:ios:import": "detox test -c ios.sim.debug -o e2e/import.test.ts",
+        "open:ios": "open -a \"Xcode\" ios",
+        "open:android": "open -a \"Android Studio\" android",
         "deploy": "yarn clean && NODE_ENV=production APP_VARIANT=production EXPO_WEB=true expo export -p web && cp playstore_policy.html dist/ && gh-pages -t -d dist --dest playground",
         "predeploy": "APP_VARIANT=production EXPO_WEB=true expo export -p web",
         "serve:dev": "yarn clean && NODE_ENV=development APP_VARIANT=development EXPO_WEB=true expo export -p web && yarn serve dist/"

--- a/documentation_site/docs/api-reference/recording-config.md
+++ b/documentation_site/docs/api-reference/recording-config.md
@@ -10,7 +10,13 @@ The recording configuration specifies the settings used for audio recording on d
 - On IOS: 48kHz sample rate, 16-bit depth, 1 channel.
 - On the web, default configuration is 44.1kHz sample rate, 32-bit depth, 1 channel.
 
-> **Important Note for iOS Simulator Users**: When working with the iOS simulator, be aware that it has limitations regarding supported recording frequencies. For example, while real iOS devices support various sample rates (16kHz, 44.1kHz, 48kHz), the simulator may only work properly with 44.1kHz. Using unsupported frequencies in the simulator may cause the app to crash. Always test audio recording functionality on real devices for accurate behavior and support of all sample rates.
+> **Note on iOS Recording**: The library now automatically detects and adapts to the hardware's actual sample rate on both iOS devices and simulators. This means you can specify any supported sample rate (e.g., 16kHz, 44.1kHz, 48kHz) in your configuration, and the library will:
+> 
+> 1. Capture audio at the hardware's native sample rate (typically 44.1kHz on simulators)
+> 2. Perform high-quality resampling to match your requested sample rate
+> 3. Deliver the final recording at your specified configuration
+> 
+> This automatic adaptation prevents crashes that previously occurred when the requested sample rate didn't match the hardware capabilities, especially in simulators.
 
 ```tsx
 export interface RecordingConfig {
@@ -68,9 +74,11 @@ On Android, the recording is managed using Android's native `AudioRecord` API al
 
 ### iOS
 
-On iOS, the recording is managed using `AVAudioEngine` and related classes from the `AVFoundation` framework. The implementation uses a sophisticated resampling approach that:
-- Captures audio at the hardware's native sample rate
+On iOS, the recording is managed using `AVAudioEngine` and related classes from the `AVFoundation` framework. The implementation uses a sophisticated audio handling approach that:
+- Automatically detects and adapts to the hardware's native sample rate
+- Handles sample rate mismatches between iOS audio session and actual hardware capabilities
 - Performs high-quality resampling to match the requested configuration
+- Works reliably on both physical devices and simulators regardless of the requested sample rate
 - Supports both 16-bit and 32-bit PCM formats
 - Maintains audio quality through intermediate Float32 format when necessary
 


### PR DESCRIPTION
# Description

## Purpose and Impact
This pull request addresses critical issues related to audio recording on iOS devices and simulators, specifically targeting the sample rate mismatch problem reported in issues #192 and #189. The changes ensure that the `expo-audio-stream` library can reliably handle audio recording by automatically detecting and adapting to the hardware's actual sample rate, preventing crashes due to mismatched sample rates (e.g., when the iOS simulator or device does not honor the requested sample rate). Additionally, this PR improves the developer experience by adding detailed logging for sample rate detection and updating the documentation to reflect the new behavior.

The key impacts of these changes are:
- **Improved Stability**: Eliminates crashes caused by sample rate mismatches, particularly on iOS simulators (e.g., when using 44.1kHz instead of the supported 48kHz).
- **Better Compatibility**: Ensures consistent audio recording across both physical iOS devices and simulators, regardless of the requested sample rate.
- **Enhanced Debugging**: Adds detailed logging to help developers understand the sample rate behavior and troubleshoot issues more effectively.
- **Clear Documentation**: Updates the API reference to inform users about the automatic sample rate adaptation, reducing confusion and improving the developer experience.

- Fixes #189
- Fixes #192 
- Fixes #193

## Key Implementation Details
1. **Sample Rate Detection and Adaptation**:
   - Modified `AudioStreamManager.swift` to query the actual hardware sample rate directly from the `AVAudioEngine` input node (`inputNode.outputFormat(forBus: 0)`), rather than relying on the iOS audio session's reported sample rate (`session.sampleRate`). This ensures the library uses the correct hardware sample rate for recording.
   - The library now captures audio at the hardware's native sample rate and performs high-quality resampling to match the user-specified sample rate in the `RecordingConfig`.
   - Added detailed logging to report the requested sample rate, the iOS session's reported rate, and the actual hardware sample rate, making it easier to debug issues (e.g., "Sample rate detection: Requested rate: 48000Hz, iOS session reported rate: 44100Hz, Input node actual rate: 44100Hz").

2. **Audio Format Configuration**:
   - Updated the audio format configuration to use the actual hardware sample rate for the `AVAudioFormat` used in the `audioEngine.inputNode.installTap` call, ensuring the tap matches the hardware capabilities.
   - The final output is resampled to the user-specified sample rate, maintaining audio quality through intermediate `Float32` format when necessary.

3. **Documentation Updates**:
   - Updated `recording-config.md` to document the new automatic sample rate adaptation behavior, explaining how the library handles sample rate mismatches and ensures compatibility across iOS devices and simulators.
   - Removed outdated warnings about simulator limitations, as the new implementation resolves these issues.

