### PR TITLE
feat(audio-stream): enhance background audio handling and permission checks

### DIFF
--- a/documentation_site/docs/installation.md
+++ b/documentation_site/docs/installation.md
@@ -87,6 +87,10 @@ You can customize the plugin's behavior by providing options:
 - **enableBackgroundAudio** (default: `true`):
   - Enables background audio recording capabilities
   - Adds FOREGROUND_SERVICE and FOREGROUND_SERVICE_MICROPHONE permissions on Android
+  - When disabled, the app won't check for FOREGROUND_SERVICE_MICROPHONE permission at runtime,
+    allowing foreground-only recording on Android 14+ without requiring this permission
+  - Note: FOREGROUND_SERVICE_MICROPHONE permission is only required on Android 14 (API level 34) 
+    and higher when performing background recording
 
 #### iOS Background Modes
 - **iosBackgroundModes**:

--- a/packages/expo-audio-studio/android/src/main/java/net/siteed/audiostream/AudioRecorderManager.kt
+++ b/packages/expo-audio-studio/android/src/main/java/net/siteed/audiostream/AudioRecorderManager.kt
@@ -38,7 +38,8 @@ class AudioRecorderManager(
     private val permissionUtils: PermissionUtils,
     private val audioDataEncoder: AudioDataEncoder,
     private val eventSender: EventSender,
-    private val enablePhoneStateHandling: Boolean = true
+    private val enablePhoneStateHandling: Boolean = true,
+    private val enableBackgroundAudio: Boolean = true
 ) {
     private var audioRecord: AudioRecord? = null
     private var bufferSizeInBytes = 0
@@ -232,12 +233,13 @@ class AudioRecorderManager(
             permissionUtils: PermissionUtils,
             audioDataEncoder: AudioDataEncoder,
             eventSender: EventSender,
-            enablePhoneStateHandling: Boolean = true
+            enablePhoneStateHandling: Boolean = true,
+            enableBackgroundAudio: Boolean = true
         ): AudioRecorderManager {
             return instance ?: synchronized(this) {
                 instance ?: AudioRecorderManager(
                     context, filesDir, permissionUtils, audioDataEncoder, eventSender,
-                    enablePhoneStateHandling
+                    enablePhoneStateHandling, enableBackgroundAudio
                 ).also { instance = it }
             }
         }
@@ -441,7 +443,7 @@ class AudioRecorderManager(
     }
 
     private fun isAudioFormatSupported(sampleRate: Int, channels: Int, format: Int): Boolean {
-        if (!permissionUtils.checkRecordingPermission()) {
+        if (!permissionUtils.checkRecordingPermission(enableBackgroundAudio)) {
             throw SecurityException("Recording permission has not been granted")
         }
 
@@ -477,7 +479,7 @@ class AudioRecorderManager(
     }
 
     private fun checkPermissions(options: Map<String, Any?>, promise: Promise): Boolean {
-        if (!permissionUtils.checkRecordingPermission()) {
+        if (!permissionUtils.checkRecordingPermission(enableBackgroundAudio)) {
             promise.reject(
                 "PERMISSION_DENIED",
                 "Recording permission has not been granted",
@@ -595,7 +597,7 @@ class AudioRecorderManager(
 
 
     private fun initializeAudioRecord(promise: Promise): Boolean {
-        if (!permissionUtils.checkRecordingPermission()) {
+        if (!permissionUtils.checkRecordingPermission(enableBackgroundAudio)) {
             promise.reject(
                 "PERMISSION_DENIED",
                 "Recording permission has not been granted",


### PR DESCRIPTION
# Description

This pull request introduces enhanced background audio handling and improved permission management for the Expo Audio Stream module. The changes aim to provide better control over audio recording in background scenarios while maintaining compatibility with Android's evolving permission requirements, particularly for Android 14+.

- Fixes #199 

### Purpose and Impact
- **Background Audio Support**: Adds a new `enableBackgroundAudio` flag to explicitly enable or disable background audio recording capabilities.
- **Permission Flexibility**: Updates permission checks to conditionally require `FOREGROUND_SERVICE_MICROPHONE` permission only when background audio is enabled, improving compatibility and reducing unnecessary permission requests.
- **Debugging Clarity**: Enhances logging around permission checks to provide better visibility into permission states, aiding in debugging and maintenance.
- **Android 14+ Compliance**: Aligns with Android 14's stricter foreground service requirements by integrating `FOREGROUND_SERVICE_MICROPHONE` permission handling where applicable.

These changes improve the module's flexibility for apps that may or may not need background audio recording, while ensuring compliance with modern Android standards.

### Key Implementation Details
1. **New `enableBackgroundAudio` Flag**:
   - Added to `AudioRecorderManager` and `ExpoAudioStreamModule` constructors with a default value of `true` in `AudioRecorderManager` and `false` in `ExpoAudioStreamModule` (determined by manifest permissions).
   - Controls whether background audio features are active and whether foreground service permissions are required.

2. **Permission Checks**:
   - Modified `PermissionUtils.checkRecordingPermission` to accept an `enableBackgroundAudio` parameter, conditionally checking `FOREGROUND_SERVICE_MICROPHONE` on Android 14+ only when background audio is enabled.
   - Retained an overload of `checkRecordingPermission()` without parameters for backward compatibility, defaulting to `true`.

3. **Manifest-Based Configuration**:
   - `ExpoAudioStreamModule` now checks the app's manifest for `FOREGROUND_SERVICE` permission to set `enableBackgroundAudio`, ensuring the feature aligns with the app's declared capabilities.

4. **Logging Enhancements**:
   - Added detailed logs in `PermissionUtils` and `ExpoAudioStreamModule` to report permission states, including whether background audio is enabled or disabled.

5. **Code Updates**:
   - Updated `AudioRecorderManager` to pass `enableBackgroundAudio` through its initialization and permission checks.
   - Adjusted `ExpoAudioStreamModule` to integrate the flag and conditionally request `FOREGROUND_SERVICE_MICROPHONE` permission.

### Breaking Changes
- **None**: The changes are designed to be backward compatible:
  - The default behavior of `checkRecordingPermission()` remains unchanged unless explicitly overridden.
  - Apps not using background audio can continue functioning without modification, as `enableBackgroundAudio` defaults to `false` in `ExpoAudioStreamModule` unless the manifest includes `FOREGROUND_SERVICE`.

### Migration Steps
- **Optional**: If your app requires background audio recording:
  1. Ensure `FOREGROUND_SERVICE` is included in your app's `AndroidManifest.xml` to enable the feature automatically.
  2. No code changes are required unless you need to explicitly disable background audio by setting `enableBackgroundAudio` to `false`.
- **No Action Needed**: If your app does not use background audio, no changes are necessary, as the default configuration avoids requesting unnecessary permissions.

### Testing Instructions
1. **Basic Recording**:
   - Test audio recording with `enableBackgroundAudio = false` to ensure standard foreground recording works without requiring `FOREGROUND_SERVICE_MICROPHONE`.
   - Verify logs show "FOREGROUND_SERVICE_MICROPHONE not required" on Android 14+.

2. **Background Audio**:
   - Add `FOREGROUND_SERVICE` to the manifest, then test recording with the app in the background.
   - Confirm that `FOREGROUND_SERVICE_MICROPHONE` is requested on Android 14+ and that recording continues seamlessly.

3. **Permission Denial**:
   - Deny `RECORD_AUDIO` or `FOREGROUND_SERVICE_MICROPHONE` permissions and verify that appropriate errors are thrown with clear log messages.

4. **Android Versions**:
   - Test on Android 13 and below to ensure no regression in behavior.
   - Test on Android 14+ with and without background audio enabled to validate conditional permission logic.

### Special Considerations
- **Manifest Permissions**: Ensure your app's manifest aligns with your intended use case. Omitting `FOREGROUND_SERVICE` will disable background audio by default.
- **Log Review**: Check logs during testing to confirm permission states are correctly reported, especially on Android 14+ devices.
- **Performance**: The additional permission checks and logging should have negligible performance impact, but monitor for any unexpected behavior in resource-constrained scenarios.