### PR TITLE
fix(ios): ensure complete audio data emission on recording stop/pause

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -33667,11 +33667,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^4.6.4 || ^5.2.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.2.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.3.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.4.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.8.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.8.3#optional!builtin<compat/typescript>":
   version: 5.8.3
-  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=b45daf"
+  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/98470634034ec37fd9ea61cc82dcf9a27950d0117a4646146b767d085a2ec14b137aae9642a83d1c62732d7fdcdac19bb6288b0bb468a72f7a06ae4e1d2c72c9
+  checksum: 10/b9b1e73dabac5dc730c041325dbd9c99467c1b0d239f1b74ec3b90d831384af3e2ba973946232df670519147eb51a2c20f6f96163cea2b359f03de1e2091cc4f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description
This pull request addresses issues where the final buffer of audio data was not emitted when stopping or pausing recordings on iOS, resolving issues #212 and #204. Additionally, it includes a minor lockfile update to maintain dependency consistency.

- Fixes #212 
- Fixes #204 

## Purpose and Impact
The primary change ensures that all recorded audio data, including the final buffer (typically 960 bytes), is emitted when a recording is stopped or paused. Previously, if the accumulated data hadn't reached the emission interval threshold, it was discarded, leading to incomplete recordings. This fix guarantees complete audio capture, improving the reliability of the recording feature in the expo-audio-studio package for iOS users.


## Key Implementation Details
- **AudioStreamManager.swift**:
  - Modified `pauseRecording` and `stopRecording` methods to check for remaining `accumulatedData` before changing the recording state.
  - Emits any pending audio data to the delegate with associated metadata (recording time, total data size).
  - Creates a copy of `accumulatedData` before emission to prevent race conditions, then clears the original buffer.
  - Preserves existing emission interval logic to avoid altering the recording pipeline's behavior.

## Breaking Changes
None. The changes are backward-compatible and do not alter the public API or expected behavior of the recording functionality.

## Migration Steps
No migration is required, as the fix is contained within the internal logic of `AudioStreamManager` and the lockfile update is non-functional.
