### PR TITLE
Fix/iosprepare

### DIFF
--- a/apps/playground/src/component/RecordingSettings.tsx
+++ b/apps/playground/src/component/RecordingSettings.tsx
@@ -210,24 +210,33 @@ export function RecordingSettings({
         <>
           <View>
             <Text variant="titleMedium" style={{ marginBottom: 8 }}>Compression Format</Text>
-            <SegmentedButtons
-              value={config.compression?.format || 'opus'}
-              onValueChange={(value) => {
-                const updatedConfig = {
-                  ...config,
-                  compression: {
-                    ...(config.compression ?? { enabled: true, bitrate: DEFAULT_BITRATE }),
-                    format: value as 'aac' | 'opus',
-                  },
-                };
-                onConfigChange(updatedConfig);
-              }}
-              buttons={[
-                { value: 'opus', label: 'OPUS' },
-                // Only show AAC option for native platforms
-                ...(!isWeb ? [{ value: 'aac', label: 'AAC' }] : []),
-              ]}
-            />
+            {Platform.OS === 'ios' ? (
+              <>
+                <Text>AAC</Text>
+                <Text variant="bodySmall" style={{ marginTop: 4, color: theme.colors.outline }}>
+                  Only AAC format is supported on iOS devices.
+                </Text>
+              </>
+            ) : (
+              <SegmentedButtons
+                value={config.compression?.format || 'opus'}
+                onValueChange={(value) => {
+                  const updatedConfig = {
+                    ...config,
+                    compression: {
+                      ...(config.compression ?? { enabled: true, bitrate: DEFAULT_BITRATE }),
+                      format: value as 'aac' | 'opus',
+                    },
+                  };
+                  onConfigChange(updatedConfig);
+                }}
+                buttons={[
+                  { value: 'opus', label: 'OPUS' },
+                  // Only show AAC option for native platforms
+                  ...(!isWeb ? [{ value: 'aac', label: 'AAC' }] : []),
+                ]}
+              />
+            )}
           </View>
           
           <View>
@@ -238,7 +247,7 @@ export function RecordingSettings({
                 const updatedConfig = {
                   ...config,
                   compression: {
-                    ...(config.compression ?? { enabled: true, format: 'opus' }),
+                    ...(config.compression ?? { enabled: true, format: Platform.OS === 'ios' ? 'aac' : 'opus' }),
                     bitrate: parseInt(value, 10),
                   },
                 };

--- a/apps/playground/src/component/RecordingSettings.tsx
+++ b/apps/playground/src/component/RecordingSettings.tsx
@@ -157,23 +157,88 @@ export function RecordingSettings({
         />
       </View>
       
-      <View>
-        <Text variant="titleMedium" style={{ marginBottom: 8 }}>Encoding</Text>
-        <SegmentedButtons
-          value={config.encoding || 'pcm_32bit'}
-          onValueChange={(value) => {
+      <View style={{ 
+        backgroundColor: theme.colors.surfaceVariant,
+        borderRadius: 8,
+        padding: 12,
+        marginVertical: 8
+      }}>
+        <Text variant="titleMedium" style={{ marginBottom: 12 }}>Compression Settings</Text>
+        
+        <LabelSwitch
+          label="Enable Compression"
+          value={config.compression?.enabled ?? true}
+          onValueChange={(enabled) => {
             const updatedConfig = {
               ...config,
-              encoding: value as RecordingConfig['encoding'],
+              compression: {
+                ...(config.compression ?? { format: 'opus', bitrate: DEFAULT_BITRATE }),
+                enabled,
+              },
             };
             onConfigChange(updatedConfig);
           }}
-          buttons={[
-            { value: 'pcm_16bit', label: '16-bit' },
-            { value: 'pcm_32bit', label: '32-bit' },
-            { value: 'pcm_8bit', label: '8-bit' },
-          ]}
+          disabled={isDisabled}
         />
+
+        {config.compression?.enabled && (
+          <View style={{ marginLeft: 12, marginTop: 8 }}>
+            <View>
+              <Text variant="titleSmall" style={{ marginBottom: 8 }}>Format</Text>
+              {Platform.OS === 'ios' ? (
+                <>
+                  <Text>AAC</Text>
+                  <Text variant="bodySmall" style={{ marginTop: 4, color: theme.colors.outline }}>
+                    Only AAC format is supported on iOS devices.
+                  </Text>
+                </>
+              ) : (
+                <SegmentedButtons
+                  value={config.compression?.format || 'opus'}
+                  onValueChange={(value) => {
+                    const updatedConfig = {
+                      ...config,
+                      compression: {
+                        ...(config.compression ?? { enabled: true, bitrate: DEFAULT_BITRATE }),
+                        format: value as 'aac' | 'opus',
+                      },
+                    };
+                    onConfigChange(updatedConfig);
+                  }}
+                  buttons={[
+                    { value: 'opus', label: 'OPUS' },
+                    ...(!isWeb ? [{ value: 'aac', label: 'AAC' }] : []),
+                  ]}
+                />
+              )}
+            </View>
+            
+            <View style={{ marginTop: 12 }}>
+              <Text variant="titleSmall" style={{ marginBottom: 8 }}>Bitrate</Text>
+              <SegmentedButtons
+                value={String(config.compression?.bitrate || DEFAULT_BITRATE)}
+                onValueChange={(value) => {
+                  const updatedConfig = {
+                    ...config,
+                    compression: {
+                      ...(config.compression ?? { enabled: true, format: Platform.OS === 'ios' ? 'aac' : 'opus' }),
+                      bitrate: parseInt(value, 10),
+                    },
+                  };
+                  onConfigChange(updatedConfig);
+                }}
+                buttons={[
+                  { value: '32000', label: '32 kbps (Voice)' },
+                  { value: '64000', label: '64 kbps (Studio)' },
+                ]}
+              />
+            </View>
+            
+            <Text variant="bodySmall" style={{ marginTop: 12, color: theme.colors.outline }}>
+              Compression reduces file size but may affect audio quality. Higher bitrates preserve more detail.
+            </Text>
+          </View>
+        )}
       </View>
       
       <SegmentDurationSelector
@@ -189,78 +254,6 @@ export function RecordingSettings({
         maxDurationMs={1000}
         skipConfirmation
       />
-      
-      <LabelSwitch
-        label="Enable Compression"
-        value={config.compression?.enabled ?? true}
-        onValueChange={(enabled) => {
-          const updatedConfig = {
-            ...config,
-            compression: {
-              ...(config.compression ?? { format: 'opus', bitrate: DEFAULT_BITRATE }),
-              enabled,
-            },
-          };
-          onConfigChange(updatedConfig);
-        }}
-        disabled={isDisabled}
-      />
-
-      {config.compression?.enabled && (
-        <>
-          <View>
-            <Text variant="titleMedium" style={{ marginBottom: 8 }}>Compression Format</Text>
-            {Platform.OS === 'ios' ? (
-              <>
-                <Text>AAC</Text>
-                <Text variant="bodySmall" style={{ marginTop: 4, color: theme.colors.outline }}>
-                  Only AAC format is supported on iOS devices.
-                </Text>
-              </>
-            ) : (
-              <SegmentedButtons
-                value={config.compression?.format || 'opus'}
-                onValueChange={(value) => {
-                  const updatedConfig = {
-                    ...config,
-                    compression: {
-                      ...(config.compression ?? { enabled: true, bitrate: DEFAULT_BITRATE }),
-                      format: value as 'aac' | 'opus',
-                    },
-                  };
-                  onConfigChange(updatedConfig);
-                }}
-                buttons={[
-                  { value: 'opus', label: 'OPUS' },
-                  // Only show AAC option for native platforms
-                  ...(!isWeb ? [{ value: 'aac', label: 'AAC' }] : []),
-                ]}
-              />
-            )}
-          </View>
-          
-          <View>
-            <Text variant="titleMedium" style={{ marginBottom: 8 }}>Bitrate</Text>
-            <SegmentedButtons
-              value={String(config.compression?.bitrate || DEFAULT_BITRATE)}
-              onValueChange={(value) => {
-                const updatedConfig = {
-                  ...config,
-                  compression: {
-                    ...(config.compression ?? { enabled: true, format: Platform.OS === 'ios' ? 'aac' : 'opus' }),
-                    bitrate: parseInt(value, 10),
-                  },
-                };
-                onConfigChange(updatedConfig);
-              }}
-              buttons={[
-                { value: '32000', label: '32 kbps (Voice)' },
-                { value: '64000', label: '64 kbps (Studio)' },
-              ]}
-            />
-          </View>
-        </>
-      )}
       
       <LabelSwitch
         label="Keep Recording in Background"

--- a/documentation_site/docs/api-reference/API/README.md
+++ b/documentation_site/docs/api-reference/API/README.md
@@ -45,6 +45,7 @@
 - [WaveformConfig](interfaces/WaveformConfig.md)
 - [WavFileInfo](interfaces/WavFileInfo.md)
 - [WavHeaderOptions](interfaces/WavHeaderOptions.md)
+- [WebConfig](interfaces/WebConfig.md)
 
 ## Type Aliases
 

--- a/documentation_site/docs/api-reference/API/classes/AudioDeviceManager.md
+++ b/documentation_site/docs/api-reference/API/classes/AudioDeviceManager.md
@@ -6,7 +6,7 @@
 
 # Class: AudioDeviceManager
 
-Defined in: [src/AudioDeviceManager.ts:54](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioDeviceManager.ts#L54)
+Defined in: [src/AudioDeviceManager.ts:54](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioDeviceManager.ts#L54)
 
 Class that provides a cross-platform API for managing audio input devices
 
@@ -16,7 +16,7 @@ Class that provides a cross-platform API for managing audio input devices
 
 > **new AudioDeviceManager**(`options`?): [`AudioDeviceManager`](AudioDeviceManager.md)
 
-Defined in: [src/AudioDeviceManager.ts:66](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioDeviceManager.ts#L66)
+Defined in: [src/AudioDeviceManager.ts:66](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioDeviceManager.ts#L66)
 
 #### Parameters
 
@@ -36,7 +36,7 @@ Defined in: [src/AudioDeviceManager.ts:66](https://github.com/deeeed/expo-audio-
 
 > **addDeviceChangeListener**(`listener`): () => `void`
 
-Defined in: [src/AudioDeviceManager.ts:265](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioDeviceManager.ts#L265)
+Defined in: [src/AudioDeviceManager.ts:265](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioDeviceManager.ts#L265)
 
 Register a listener for device changes
 
@@ -64,7 +64,7 @@ Function to remove the listener
 
 > **getAvailableDevices**(`options`?): `Promise`\<[`AudioDevice`](../interfaces/AudioDevice.md)[]\>
 
-Defined in: [src/AudioDeviceManager.ts:136](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioDeviceManager.ts#L136)
+Defined in: [src/AudioDeviceManager.ts:136](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioDeviceManager.ts#L136)
 
 Get all available audio input devices
 
@@ -90,7 +90,7 @@ Promise resolving to an array of audio devices conforming to AudioDevice interfa
 
 > **getCurrentDevice**(): `Promise`\<`null` \| [`AudioDevice`](../interfaces/AudioDevice.md)\>
 
-Defined in: [src/AudioDeviceManager.ts:168](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioDeviceManager.ts#L168)
+Defined in: [src/AudioDeviceManager.ts:168](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioDeviceManager.ts#L168)
 
 Get the currently selected audio input device
 
@@ -106,7 +106,7 @@ Promise resolving to the current device (conforming to AudioDevice) or null
 
 > **initWithLogger**(`logger`): [`AudioDeviceManager`](AudioDeviceManager.md)
 
-Defined in: [src/AudioDeviceManager.ts:118](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioDeviceManager.ts#L118)
+Defined in: [src/AudioDeviceManager.ts:118](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioDeviceManager.ts#L118)
 
 Initialize the device manager with a logger
 
@@ -130,7 +130,7 @@ The manager instance for chaining
 
 > **refreshDevices**(): `Promise`\<[`AudioDevice`](../interfaces/AudioDevice.md)[]\>
 
-Defined in: [src/AudioDeviceManager.ts:285](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioDeviceManager.ts#L285)
+Defined in: [src/AudioDeviceManager.ts:285](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioDeviceManager.ts#L285)
 
 Refresh the list of available devices with debouncing and notify listeners.
 
@@ -146,7 +146,7 @@ Promise resolving to the updated device list (AudioDevice[])
 
 > **resetToDefaultDevice**(): `Promise`\<`boolean`\>
 
-Defined in: [src/AudioDeviceManager.ts:238](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioDeviceManager.ts#L238)
+Defined in: [src/AudioDeviceManager.ts:238](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioDeviceManager.ts#L238)
 
 Reset to the default audio input device
 
@@ -162,7 +162,7 @@ Promise resolving to a boolean indicating success
 
 > **selectDevice**(`deviceId`): `Promise`\<`boolean`\>
 
-Defined in: [src/AudioDeviceManager.ts:202](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioDeviceManager.ts#L202)
+Defined in: [src/AudioDeviceManager.ts:202](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioDeviceManager.ts#L202)
 
 Select a specific audio input device for recording
 
@@ -186,7 +186,7 @@ Promise resolving to a boolean indicating success
 
 > **setLogger**(`logger`): `void`
 
-Defined in: [src/AudioDeviceManager.ts:127](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioDeviceManager.ts#L127)
+Defined in: [src/AudioDeviceManager.ts:127](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioDeviceManager.ts#L127)
 
 Set the logger instance
 

--- a/documentation_site/docs/api-reference/API/functions/AudioRecorderProvider.md
+++ b/documentation_site/docs/api-reference/API/functions/AudioRecorderProvider.md
@@ -8,7 +8,7 @@
 
 > **AudioRecorderProvider**(`props`, `deprecatedLegacyContext`?): `ReactNode`
 
-Defined in: [src/AudioRecorder.provider.tsx:37](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioRecorder.provider.tsx#L37)
+Defined in: [src/AudioRecorder.provider.tsx:37](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioRecorder.provider.tsx#L37)
 
 ## Parameters
 

--- a/documentation_site/docs/api-reference/API/functions/convertPCMToFloat32.md
+++ b/documentation_site/docs/api-reference/API/functions/convertPCMToFloat32.md
@@ -8,7 +8,7 @@
 
 > **convertPCMToFloat32**(`__namedParameters`): `Promise`\<\{ `max`: `number`; `min`: `number`; `pcmValues`: `Float32Array`; \}\>
 
-Defined in: [src/utils/convertPCMToFloat32.ts:69](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/convertPCMToFloat32.ts#L69)
+Defined in: [src/utils/convertPCMToFloat32.ts:69](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/convertPCMToFloat32.ts#L69)
 
 ## Parameters
 

--- a/documentation_site/docs/api-reference/API/functions/extractAudioAnalysis.md
+++ b/documentation_site/docs/api-reference/API/functions/extractAudioAnalysis.md
@@ -8,7 +8,7 @@
 
 > **extractAudioAnalysis**(`props`): `Promise`\<[`AudioAnalysis`](../interfaces/AudioAnalysis.md)\>
 
-Defined in: [src/AudioAnalysis/extractAudioAnalysis.ts:97](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/extractAudioAnalysis.ts#L97)
+Defined in: [src/AudioAnalysis/extractAudioAnalysis.ts:97](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/extractAudioAnalysis.ts#L97)
 
 Extracts detailed audio analysis from the specified audio file or buffer.
 Supports either time-based or byte-based ranges for flexibility in analysis.

--- a/documentation_site/docs/api-reference/API/functions/extractAudioData.md
+++ b/documentation_site/docs/api-reference/API/functions/extractAudioData.md
@@ -8,7 +8,7 @@
 
 > **extractAudioData**(`props`): `Promise`\<`any`\>
 
-Defined in: [src/AudioAnalysis/extractAudioData.ts:4](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/extractAudioData.ts#L4)
+Defined in: [src/AudioAnalysis/extractAudioData.ts:4](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/extractAudioData.ts#L4)
 
 ## Parameters
 

--- a/documentation_site/docs/api-reference/API/functions/extractMelSpectrogram.md
+++ b/documentation_site/docs/api-reference/API/functions/extractMelSpectrogram.md
@@ -8,7 +8,7 @@
 
 > **extractMelSpectrogram**(`options`): `Promise`\<[`MelSpectrogram`](../interfaces/MelSpectrogram.md)\>
 
-Defined in: [src/AudioAnalysis/extractMelSpectrogram.ts:24](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/extractMelSpectrogram.ts#L24)
+Defined in: [src/AudioAnalysis/extractMelSpectrogram.ts:24](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/extractMelSpectrogram.ts#L24)
 
 **`Experimental`**
 

--- a/documentation_site/docs/api-reference/API/functions/extractPreview.md
+++ b/documentation_site/docs/api-reference/API/functions/extractPreview.md
@@ -8,7 +8,7 @@
 
 > **extractPreview**(`options`): `Promise`\<[`AudioAnalysis`](../interfaces/AudioAnalysis.md)\>
 
-Defined in: [src/AudioAnalysis/extractPreview.ts:11](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/extractPreview.ts#L11)
+Defined in: [src/AudioAnalysis/extractPreview.ts:11](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/extractPreview.ts#L11)
 
 Generates a simplified preview of the audio waveform for quick visualization.
 Ideal for UI rendering with a specified number of points.

--- a/documentation_site/docs/api-reference/API/functions/extractRawWavAnalysis.md
+++ b/documentation_site/docs/api-reference/API/functions/extractRawWavAnalysis.md
@@ -8,7 +8,7 @@
 
 > **extractRawWavAnalysis**(`props`): `Promise`\<[`AudioAnalysis`](../interfaces/AudioAnalysis.md)\>
 
-Defined in: [src/AudioAnalysis/extractAudioAnalysis.ts:223](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/extractAudioAnalysis.ts#L223)
+Defined in: [src/AudioAnalysis/extractAudioAnalysis.ts:223](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/extractAudioAnalysis.ts#L223)
 
 Analyzes WAV files without decoding, preserving original PCM values.
 Use this function when you need to ensure the analysis matches other software by avoiding any transformations.

--- a/documentation_site/docs/api-reference/API/functions/getWavFileInfo.md
+++ b/documentation_site/docs/api-reference/API/functions/getWavFileInfo.md
@@ -8,7 +8,7 @@
 
 > **getWavFileInfo**(`arrayBuffer`): `Promise`\<[`WavFileInfo`](../interfaces/WavFileInfo.md)\>
 
-Defined in: [src/utils/getWavFileInfo.ts:47](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L47)
+Defined in: [src/utils/getWavFileInfo.ts:47](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L47)
 
 Extracts metadata from a WAV buffer.
 

--- a/documentation_site/docs/api-reference/API/functions/trimAudio.md
+++ b/documentation_site/docs/api-reference/API/functions/trimAudio.md
@@ -8,7 +8,7 @@
 
 > **trimAudio**(`options`, `progressCallback`?): `Promise`\<[`TrimAudioResult`](../interfaces/TrimAudioResult.md)\>
 
-Defined in: [src/trimAudio.ts:24](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/trimAudio.ts#L24)
+Defined in: [src/trimAudio.ts:24](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/trimAudio.ts#L24)
 
 **`Experimental`**
 

--- a/documentation_site/docs/api-reference/API/functions/useAudioDevices.md
+++ b/documentation_site/docs/api-reference/API/functions/useAudioDevices.md
@@ -8,7 +8,7 @@
 
 > **useAudioDevices**(): `object`
 
-Defined in: [src/hooks/useAudioDevices.ts:9](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/hooks/useAudioDevices.ts#L9)
+Defined in: [src/hooks/useAudioDevices.ts:9](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/hooks/useAudioDevices.ts#L9)
 
 React hook for managing audio input devices
 

--- a/documentation_site/docs/api-reference/API/functions/useAudioRecorder.md
+++ b/documentation_site/docs/api-reference/API/functions/useAudioRecorder.md
@@ -8,7 +8,7 @@
 
 > **useAudioRecorder**(`__namedParameters`): `UseAudioRecorderState`
 
-Defined in: [src/useAudioRecorder.tsx:155](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/useAudioRecorder.tsx#L155)
+Defined in: [src/useAudioRecorder.tsx:155](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/useAudioRecorder.tsx#L155)
 
 ## Parameters
 

--- a/documentation_site/docs/api-reference/API/functions/useSharedAudioRecorder.md
+++ b/documentation_site/docs/api-reference/API/functions/useSharedAudioRecorder.md
@@ -8,7 +8,7 @@
 
 > **useSharedAudioRecorder**(): [`UseAudioRecorderState`](../interfaces/UseAudioRecorderState.md)
 
-Defined in: [src/AudioRecorder.provider.tsx:49](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioRecorder.provider.tsx#L49)
+Defined in: [src/AudioRecorder.provider.tsx:49](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioRecorder.provider.tsx#L49)
 
 ## Returns
 

--- a/documentation_site/docs/api-reference/API/functions/writeWavHeader.md
+++ b/documentation_site/docs/api-reference/API/functions/writeWavHeader.md
@@ -8,7 +8,7 @@
 
 > **writeWavHeader**(`options`): `ArrayBuffer`
 
-Defined in: [src/utils/writeWavHeader.ts:51](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/writeWavHeader.ts#L51)
+Defined in: [src/utils/writeWavHeader.ts:36](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/writeWavHeader.ts#L36)
 
 Writes or updates a WAV (RIFF) header based on the provided options.
 
@@ -38,24 +38,3 @@ An ArrayBuffer containing the WAV header, or the header combined with the provid
 ## Throws
 
 Throws an error if the provided options are invalid or if the buffer is too small.
-
-## Examples
-
-```ts
-// Create a standalone WAV header
-const header = writeWavHeader({
-  sampleRate: 44100,
-  numChannels: 2,
-  bitDepth: 16
-});
-```
-
-```ts
-// Create a WAV header and combine it with audio data
-const completeWav = writeWavHeader({
-  buffer: audioData,
-  sampleRate: 44100,
-  numChannels: 2,
-  bitDepth: 16
-});
-```

--- a/documentation_site/docs/api-reference/API/interfaces/AudioAnalysis.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioAnalysis.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioAnalysis
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:101](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L101)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:101](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L101)
 
 Represents the complete data from the audio analysis.
 
@@ -16,7 +16,7 @@ Represents the complete data from the audio analysis.
 
 > **amplitudeRange**: `object`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:109](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L109)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:109](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L109)
 
 #### max
 
@@ -32,7 +32,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:109](https://github.com/de
 
 > **bitDepth**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:104](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L104)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:104](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L104)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:104](https://github.com/de
 
 > **dataPoints**: [`DataPoint`](DataPoint.md)[]
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:108](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L108)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:108](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L108)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:108](https://github.com/de
 
 > **durationMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:103](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L103)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:103](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L103)
 
 ***
 
@@ -56,7 +56,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:103](https://github.com/de
 
 > **numberOfChannels**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:106](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L106)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:106](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L106)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:106](https://github.com/de
 
 > **rmsRange**: `object`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:113](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L113)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:113](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L113)
 
 #### max
 
@@ -80,7 +80,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:113](https://github.com/de
 
 > **sampleRate**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:107](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L107)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:107](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L107)
 
 ***
 
@@ -88,7 +88,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:107](https://github.com/de
 
 > **samples**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:105](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L105)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:105](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L105)
 
 ***
 
@@ -96,7 +96,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:105](https://github.com/de
 
 > **segmentDurationMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:102](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L102)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:102](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L102)
 
 ***
 
@@ -104,7 +104,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:102](https://github.com/de
 
 > `optional` **speechAnalysis**: `object`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:118](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L118)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:118](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L118)
 
 #### speakerChanges
 

--- a/documentation_site/docs/api-reference/API/interfaces/AudioDataEvent.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioDataEvent.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioDataEvent
 
-Defined in: [src/ExpoAudioStream.types.ts:41](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L41)
+Defined in: [src/ExpoAudioStream.types.ts:41](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L41)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/ExpoAudioStream.types.ts:41](https://github.com/deeeed/expo-aud
 
 > `optional` **compression**: [`CompressionInfo`](CompressionInfo.md) & `object`
 
-Defined in: [src/ExpoAudioStream.types.ts:53](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L53)
+Defined in: [src/ExpoAudioStream.types.ts:53](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L53)
 
 Information about compression if enabled, including the compressed data chunk
 
@@ -32,7 +32,7 @@ Base64 (native) or Blob (web) encoded compressed data chunk
 
 > **data**: `string` \| `Float32Array`
 
-Defined in: [src/ExpoAudioStream.types.ts:43](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L43)
+Defined in: [src/ExpoAudioStream.types.ts:43](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L43)
 
 Audio data as base64 string (native) or Float32Array (web)
 
@@ -42,7 +42,7 @@ Audio data as base64 string (native) or Float32Array (web)
 
 > **eventDataSize**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:49](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L49)
+Defined in: [src/ExpoAudioStream.types.ts:49](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L49)
 
 Size of the current data chunk in bytes
 
@@ -52,7 +52,7 @@ Size of the current data chunk in bytes
 
 > **fileUri**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:47](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L47)
+Defined in: [src/ExpoAudioStream.types.ts:47](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L47)
 
 URI to the file being recorded
 
@@ -62,7 +62,7 @@ URI to the file being recorded
 
 > **position**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:45](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L45)
+Defined in: [src/ExpoAudioStream.types.ts:45](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L45)
 
 Current position in the audio stream in bytes
 
@@ -72,6 +72,6 @@ Current position in the audio stream in bytes
 
 > **totalSize**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:51](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L51)
+Defined in: [src/ExpoAudioStream.types.ts:51](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L51)
 
 Total size of the recording so far in bytes

--- a/documentation_site/docs/api-reference/API/interfaces/AudioDevice.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioDevice.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioDevice
 
-Defined in: [src/ExpoAudioStream.types.ts:254](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L254)
+Defined in: [src/ExpoAudioStream.types.ts:267](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L267)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/ExpoAudioStream.types.ts:254](https://github.com/deeeed/expo-au
 
 > **capabilities**: [`AudioDeviceCapabilities`](AudioDeviceCapabilities.md)
 
-Defined in: [src/ExpoAudioStream.types.ts:264](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L264)
+Defined in: [src/ExpoAudioStream.types.ts:277](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L277)
 
 Audio capabilities for the device
 
@@ -24,7 +24,7 @@ Audio capabilities for the device
 
 > **id**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:256](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L256)
+Defined in: [src/ExpoAudioStream.types.ts:269](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L269)
 
 Unique identifier for the device
 
@@ -34,7 +34,7 @@ Unique identifier for the device
 
 > **isAvailable**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:266](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L266)
+Defined in: [src/ExpoAudioStream.types.ts:279](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L279)
 
 Whether the device is currently available
 
@@ -44,7 +44,7 @@ Whether the device is currently available
 
 > **isDefault**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:262](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L262)
+Defined in: [src/ExpoAudioStream.types.ts:275](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L275)
 
 Whether this is the system default device
 
@@ -54,7 +54,7 @@ Whether this is the system default device
 
 > **name**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:258](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L258)
+Defined in: [src/ExpoAudioStream.types.ts:271](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L271)
 
 Human-readable name of the device
 
@@ -64,6 +64,6 @@ Human-readable name of the device
 
 > **type**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:260](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L260)
+Defined in: [src/ExpoAudioStream.types.ts:273](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L273)
 
 Device type (builtin_mic, bluetooth, etc.)

--- a/documentation_site/docs/api-reference/API/interfaces/AudioDeviceCapabilities.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioDeviceCapabilities.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioDeviceCapabilities
 
-Defined in: [src/ExpoAudioStream.types.ts:239](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L239)
+Defined in: [src/ExpoAudioStream.types.ts:252](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L252)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/ExpoAudioStream.types.ts:239](https://github.com/deeeed/expo-au
 
 > **bitDepths**: `number`[]
 
-Defined in: [src/ExpoAudioStream.types.ts:245](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L245)
+Defined in: [src/ExpoAudioStream.types.ts:258](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L258)
 
 Supported bit depths for the device
 
@@ -24,7 +24,7 @@ Supported bit depths for the device
 
 > **channelCounts**: `number`[]
 
-Defined in: [src/ExpoAudioStream.types.ts:243](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L243)
+Defined in: [src/ExpoAudioStream.types.ts:256](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L256)
 
 Supported channel counts for the device
 
@@ -34,7 +34,7 @@ Supported channel counts for the device
 
 > `optional` **hasAutomaticGainControl**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:251](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L251)
+Defined in: [src/ExpoAudioStream.types.ts:264](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L264)
 
 Whether the device supports automatic gain control
 
@@ -44,7 +44,7 @@ Whether the device supports automatic gain control
 
 > `optional` **hasEchoCancellation**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:247](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L247)
+Defined in: [src/ExpoAudioStream.types.ts:260](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L260)
 
 Whether the device supports echo cancellation
 
@@ -54,7 +54,7 @@ Whether the device supports echo cancellation
 
 > `optional` **hasNoiseSuppression**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:249](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L249)
+Defined in: [src/ExpoAudioStream.types.ts:262](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L262)
 
 Whether the device supports noise suppression
 
@@ -64,6 +64,6 @@ Whether the device supports noise suppression
 
 > **sampleRates**: `number`[]
 
-Defined in: [src/ExpoAudioStream.types.ts:241](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L241)
+Defined in: [src/ExpoAudioStream.types.ts:254](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L254)
 
 Supported sample rates for the device

--- a/documentation_site/docs/api-reference/API/interfaces/AudioFeatures.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioFeatures.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioFeatures
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:35](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L35)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:35](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L35)
 
 Represents various audio features extracted from an audio signal.
 
@@ -16,7 +16,7 @@ Represents various audio features extracted from an audio signal.
 
 > `optional` **chromagram**: `number`[]
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:46](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L46)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:46](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L46)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:46](https://github.com/dee
 
 > `optional` **crc32**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:53](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L53)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:53](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L53)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:53](https://github.com/dee
 
 > `optional` **energy**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:36](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L36)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:36](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L36)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:36](https://github.com/dee
 
 > `optional` **hnr**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:48](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L48)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:48](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L48)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:48](https://github.com/dee
 
 > `optional` **maxAmplitude**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:40](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L40)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:40](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L40)
 
 ***
 
@@ -56,7 +56,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:40](https://github.com/dee
 
 > `optional` **melSpectrogram**: `number`[]
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:49](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L49)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:49](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L49)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:49](https://github.com/dee
 
 > `optional` **mfcc**: `number`[]
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:37](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L37)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:37](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L37)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:37](https://github.com/dee
 
 > `optional` **minAmplitude**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:39](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L39)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:39](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L39)
 
 ***
 
@@ -80,7 +80,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:39](https://github.com/dee
 
 > `optional` **pitch**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:52](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L52)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:52](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L52)
 
 ***
 
@@ -88,7 +88,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:52](https://github.com/dee
 
 > `optional` **rms**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:38](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L38)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:38](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L38)
 
 ***
 
@@ -96,7 +96,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:38](https://github.com/dee
 
 > `optional` **spectralBandwidth**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:45](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L45)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:45](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L45)
 
 ***
 
@@ -104,7 +104,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:45](https://github.com/dee
 
 > `optional` **spectralCentroid**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:42](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L42)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:42](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L42)
 
 ***
 
@@ -112,7 +112,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:42](https://github.com/dee
 
 > `optional` **spectralContrast**: `number`[]
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:50](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L50)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:50](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L50)
 
 ***
 
@@ -120,7 +120,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:50](https://github.com/dee
 
 > `optional` **spectralFlatness**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:43](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L43)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:43](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L43)
 
 ***
 
@@ -128,7 +128,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:43](https://github.com/dee
 
 > `optional` **spectralRolloff**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:44](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L44)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:44](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L44)
 
 ***
 
@@ -136,7 +136,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:44](https://github.com/dee
 
 > `optional` **tempo**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:47](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L47)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:47](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L47)
 
 ***
 
@@ -144,7 +144,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:47](https://github.com/dee
 
 > `optional` **tonnetz**: `number`[]
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:51](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L51)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:51](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L51)
 
 ***
 
@@ -152,4 +152,4 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:51](https://github.com/dee
 
 > `optional` **zcr**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:41](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L41)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:41](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L41)

--- a/documentation_site/docs/api-reference/API/interfaces/AudioFeaturesOptions.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioFeaturesOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioFeaturesOptions
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:59](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L59)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:59](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L59)
 
 Options to specify which audio features to extract.
 
@@ -16,7 +16,7 @@ Options to specify which audio features to extract.
 
 > `optional` **chromagram**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:68](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L68)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:68](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L68)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:68](https://github.com/dee
 
 > `optional` **crc32**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:75](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L75)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:75](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L75)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:75](https://github.com/dee
 
 > `optional` **energy**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:60](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L60)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:60](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L60)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:60](https://github.com/dee
 
 > `optional` **hnr**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:70](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L70)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:70](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L70)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:70](https://github.com/dee
 
 > `optional` **melSpectrogram**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:71](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L71)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:71](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L71)
 
 ***
 
@@ -56,7 +56,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:71](https://github.com/dee
 
 > `optional` **mfcc**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:61](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L61)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:61](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L61)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:61](https://github.com/dee
 
 > `optional` **pitch**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:74](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L74)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:74](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L74)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:74](https://github.com/dee
 
 > `optional` **rms**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:62](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L62)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:62](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L62)
 
 ***
 
@@ -80,7 +80,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:62](https://github.com/dee
 
 > `optional` **spectralBandwidth**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:67](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L67)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:67](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L67)
 
 ***
 
@@ -88,7 +88,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:67](https://github.com/dee
 
 > `optional` **spectralCentroid**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:64](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L64)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:64](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L64)
 
 ***
 
@@ -96,7 +96,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:64](https://github.com/dee
 
 > `optional` **spectralContrast**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:72](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L72)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:72](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L72)
 
 ***
 
@@ -104,7 +104,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:72](https://github.com/dee
 
 > `optional` **spectralFlatness**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:65](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L65)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:65](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L65)
 
 ***
 
@@ -112,7 +112,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:65](https://github.com/dee
 
 > `optional` **spectralRolloff**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:66](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L66)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:66](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L66)
 
 ***
 
@@ -120,7 +120,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:66](https://github.com/dee
 
 > `optional` **tempo**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:69](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L69)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:69](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L69)
 
 ***
 
@@ -128,7 +128,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:69](https://github.com/dee
 
 > `optional` **tonnetz**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:73](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L73)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:73](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L73)
 
 ***
 
@@ -136,4 +136,4 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:73](https://github.com/dee
 
 > `optional` **zcr**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:63](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L63)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:63](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L63)

--- a/documentation_site/docs/api-reference/API/interfaces/AudioRangeOptions.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioRangeOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioRangeOptions
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:133](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L133)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:133](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L133)
 
 Options for specifying a time range within an audio file.
 
@@ -20,7 +20,7 @@ Options for specifying a time range within an audio file.
 
 > `optional` **endTimeMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:137](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L137)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:137](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L137)
 
 End time in milliseconds
 
@@ -30,6 +30,6 @@ End time in milliseconds
 
 > `optional` **startTimeMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:135](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L135)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:135](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L135)
 
 Start time in milliseconds

--- a/documentation_site/docs/api-reference/API/interfaces/AudioRecording.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioRecording.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioRecording
 
-Defined in: [src/ExpoAudioStream.types.ts:99](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L99)
+Defined in: [src/ExpoAudioStream.types.ts:99](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L99)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/ExpoAudioStream.types.ts:99](https://github.com/deeeed/expo-aud
 
 > `optional` **analysisData**: [`AudioAnalysis`](AudioAnalysis.md)
 
-Defined in: [src/ExpoAudioStream.types.ts:121](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L121)
+Defined in: [src/ExpoAudioStream.types.ts:121](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L121)
 
 Analysis data for the recording if processing was enabled
 
@@ -24,7 +24,7 @@ Analysis data for the recording if processing was enabled
 
 > **bitDepth**: [`BitDepth`](../type-aliases/BitDepth.md)
 
-Defined in: [src/ExpoAudioStream.types.ts:113](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L113)
+Defined in: [src/ExpoAudioStream.types.ts:113](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L113)
 
 Bit depth of the audio (8, 16, or 32 bits)
 
@@ -34,7 +34,7 @@ Bit depth of the audio (8, 16, or 32 bits)
 
 > **channels**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:111](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L111)
+Defined in: [src/ExpoAudioStream.types.ts:111](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L111)
 
 Number of audio channels (1 for mono, 2 for stereo)
 
@@ -44,7 +44,7 @@ Number of audio channels (1 for mono, 2 for stereo)
 
 > `optional` **compression**: [`CompressionInfo`](CompressionInfo.md) & `object`
 
-Defined in: [src/ExpoAudioStream.types.ts:123](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L123)
+Defined in: [src/ExpoAudioStream.types.ts:123](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L123)
 
 Information about compression if enabled, including the URI to the compressed file
 
@@ -62,7 +62,7 @@ URI to the compressed audio file
 
 > `optional` **createdAt**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:117](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L117)
+Defined in: [src/ExpoAudioStream.types.ts:117](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L117)
 
 Timestamp when the recording was created
 
@@ -72,7 +72,7 @@ Timestamp when the recording was created
 
 > **durationMs**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:105](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L105)
+Defined in: [src/ExpoAudioStream.types.ts:105](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L105)
 
 Duration of the recording in milliseconds
 
@@ -82,7 +82,7 @@ Duration of the recording in milliseconds
 
 > **filename**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:103](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L103)
+Defined in: [src/ExpoAudioStream.types.ts:103](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L103)
 
 Filename of the recorded audio
 
@@ -92,7 +92,7 @@ Filename of the recorded audio
 
 > **fileUri**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:101](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L101)
+Defined in: [src/ExpoAudioStream.types.ts:101](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L101)
 
 URI to the recorded audio file
 
@@ -102,7 +102,7 @@ URI to the recorded audio file
 
 > **mimeType**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:109](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L109)
+Defined in: [src/ExpoAudioStream.types.ts:109](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L109)
 
 MIME type of the recorded audio
 
@@ -112,7 +112,7 @@ MIME type of the recorded audio
 
 > **sampleRate**: [`SampleRate`](../type-aliases/SampleRate.md)
 
-Defined in: [src/ExpoAudioStream.types.ts:115](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L115)
+Defined in: [src/ExpoAudioStream.types.ts:115](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L115)
 
 Sample rate of the audio in Hz
 
@@ -122,7 +122,7 @@ Sample rate of the audio in Hz
 
 > **size**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:107](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L107)
+Defined in: [src/ExpoAudioStream.types.ts:107](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L107)
 
 Size of the recording in bytes
 
@@ -132,6 +132,6 @@ Size of the recording in bytes
 
 > `optional` **transcripts**: [`TranscriberData`](TranscriberData.md)[]
 
-Defined in: [src/ExpoAudioStream.types.ts:119](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L119)
+Defined in: [src/ExpoAudioStream.types.ts:119](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L119)
 
 Array of transcription data if available

--- a/documentation_site/docs/api-reference/API/interfaces/AudioSessionConfig.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioSessionConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioSessionConfig
 
-Defined in: [src/ExpoAudioStream.types.ts:147](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L147)
+Defined in: [src/ExpoAudioStream.types.ts:147](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L147)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/ExpoAudioStream.types.ts:147](https://github.com/deeeed/expo-au
 
 > `optional` **category**: `"Ambient"` \| `"SoloAmbient"` \| `"Playback"` \| `"Record"` \| `"PlayAndRecord"` \| `"MultiRoute"`
 
-Defined in: [src/ExpoAudioStream.types.ts:157](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L157)
+Defined in: [src/ExpoAudioStream.types.ts:157](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L157)
 
 Audio session category that defines the audio behavior
 - 'Ambient': Audio continues with silent switch, mixes with other audio
@@ -30,7 +30,7 @@ Audio session category that defines the audio behavior
 
 > `optional` **categoryOptions**: (`"MixWithOthers"` \| `"DuckOthers"` \| `"InterruptSpokenAudioAndMixWithOthers"` \| `"AllowBluetooth"` \| `"AllowBluetoothA2DP"` \| `"AllowAirPlay"` \| `"DefaultToSpeaker"`)[]
 
-Defined in: [src/ExpoAudioStream.types.ts:194](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L194)
+Defined in: [src/ExpoAudioStream.types.ts:194](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L194)
 
 Options that modify the behavior of the audio session category
 - 'MixWithOthers': Allows mixing with other active audio sessions
@@ -47,7 +47,7 @@ Options that modify the behavior of the audio session category
 
 > `optional` **mode**: `"Default"` \| `"VoiceChat"` \| `"VideoChat"` \| `"GameChat"` \| `"VideoRecording"` \| `"Measurement"` \| `"MoviePlayback"` \| `"SpokenAudio"`
 
-Defined in: [src/ExpoAudioStream.types.ts:175](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L175)
+Defined in: [src/ExpoAudioStream.types.ts:175](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L175)
 
 Audio session mode that defines the behavior for specific use cases
 - 'Default': Standard audio behavior

--- a/documentation_site/docs/api-reference/API/interfaces/AudioStreamStatus.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioStreamStatus.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioStreamStatus
 
-Defined in: [src/ExpoAudioStream.types.ts:22](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L22)
+Defined in: [src/ExpoAudioStream.types.ts:22](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L22)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/ExpoAudioStream.types.ts:22](https://github.com/deeeed/expo-aud
 
 > `optional` **compression**: [`CompressionInfo`](CompressionInfo.md)
 
-Defined in: [src/ExpoAudioStream.types.ts:38](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L38)
+Defined in: [src/ExpoAudioStream.types.ts:38](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L38)
 
 Information about audio compression if enabled
 
@@ -24,7 +24,7 @@ Information about audio compression if enabled
 
 > **durationMs**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:28](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L28)
+Defined in: [src/ExpoAudioStream.types.ts:28](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L28)
 
 Duration of the current recording in milliseconds
 
@@ -34,7 +34,7 @@ Duration of the current recording in milliseconds
 
 > **interval**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:32](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L32)
+Defined in: [src/ExpoAudioStream.types.ts:32](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L32)
 
 Interval in milliseconds at which recording data is emitted
 
@@ -44,7 +44,7 @@ Interval in milliseconds at which recording data is emitted
 
 > **intervalAnalysis**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:34](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L34)
+Defined in: [src/ExpoAudioStream.types.ts:34](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L34)
 
 Interval in milliseconds at which analysis data is emitted
 
@@ -54,7 +54,7 @@ Interval in milliseconds at which analysis data is emitted
 
 > **isPaused**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:26](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L26)
+Defined in: [src/ExpoAudioStream.types.ts:26](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L26)
 
 Indicates whether recording is in a paused state
 
@@ -64,7 +64,7 @@ Indicates whether recording is in a paused state
 
 > **isRecording**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:24](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L24)
+Defined in: [src/ExpoAudioStream.types.ts:24](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L24)
 
 Indicates whether audio recording is currently active
 
@@ -74,7 +74,7 @@ Indicates whether audio recording is currently active
 
 > **mimeType**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:36](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L36)
+Defined in: [src/ExpoAudioStream.types.ts:36](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L36)
 
 MIME type of the recorded audio (e.g., 'audio/wav')
 
@@ -84,6 +84,6 @@ MIME type of the recorded audio (e.g., 'audio/wav')
 
 > **size**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:30](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L30)
+Defined in: [src/ExpoAudioStream.types.ts:30](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L30)
 
 Size of the recorded audio data in bytes

--- a/documentation_site/docs/api-reference/API/interfaces/Chunk.md
+++ b/documentation_site/docs/api-reference/API/interfaces/Chunk.md
@@ -6,7 +6,7 @@
 
 # Interface: Chunk
 
-Defined in: [src/ExpoAudioStream.types.ts:77](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L77)
+Defined in: [src/ExpoAudioStream.types.ts:77](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L77)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/ExpoAudioStream.types.ts:77](https://github.com/deeeed/expo-aud
 
 > **text**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:79](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L79)
+Defined in: [src/ExpoAudioStream.types.ts:79](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L79)
 
 Transcribed text content
 
@@ -24,6 +24,6 @@ Transcribed text content
 
 > **timestamp**: \[`number`, `null` \| `number`\]
 
-Defined in: [src/ExpoAudioStream.types.ts:81](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L81)
+Defined in: [src/ExpoAudioStream.types.ts:81](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L81)
 
 Start and end timestamp in seconds [start, end] where end can be null if ongoing

--- a/documentation_site/docs/api-reference/API/interfaces/CompressionInfo.md
+++ b/documentation_site/docs/api-reference/API/interfaces/CompressionInfo.md
@@ -6,7 +6,7 @@
 
 # Interface: CompressionInfo
 
-Defined in: [src/ExpoAudioStream.types.ts:9](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L9)
+Defined in: [src/ExpoAudioStream.types.ts:9](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L9)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/ExpoAudioStream.types.ts:9](https://github.com/deeeed/expo-audi
 
 > **bitrate**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:15](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L15)
+Defined in: [src/ExpoAudioStream.types.ts:15](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L15)
 
 Bitrate of the compressed audio in bits per second
 
@@ -24,7 +24,7 @@ Bitrate of the compressed audio in bits per second
 
 > `optional` **compressedFileUri**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:19](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L19)
+Defined in: [src/ExpoAudioStream.types.ts:19](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L19)
 
 URI to the compressed audio file if available
 
@@ -34,7 +34,7 @@ URI to the compressed audio file if available
 
 > **format**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:17](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L17)
+Defined in: [src/ExpoAudioStream.types.ts:17](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L17)
 
 Format of the compression (e.g., 'aac', 'opus')
 
@@ -44,7 +44,7 @@ Format of the compression (e.g., 'aac', 'opus')
 
 > **mimeType**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:13](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L13)
+Defined in: [src/ExpoAudioStream.types.ts:13](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L13)
 
 MIME type of the compressed audio (e.g., 'audio/aac', 'audio/opus')
 
@@ -54,6 +54,6 @@ MIME type of the compressed audio (e.g., 'audio/aac', 'audio/opus')
 
 > **size**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:11](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L11)
+Defined in: [src/ExpoAudioStream.types.ts:11](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L11)
 
 Size of the compressed audio data in bytes

--- a/documentation_site/docs/api-reference/API/interfaces/DataPoint.md
+++ b/documentation_site/docs/api-reference/API/interfaces/DataPoint.md
@@ -6,7 +6,7 @@
 
 # Interface: DataPoint
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:81](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L81)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:81](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L81)
 
 Represents a single data point in the audio analysis.
 
@@ -16,7 +16,7 @@ Represents a single data point in the audio analysis.
 
 > **amplitude**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:83](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L83)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:83](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L83)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:83](https://github.com/dee
 
 > **dB**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:85](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L85)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:85](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L85)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:85](https://github.com/dee
 
 > `optional` **endPosition**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:93](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L93)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:93](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L93)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:93](https://github.com/dee
 
 > `optional` **endTime**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:90](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L90)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:90](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L90)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:90](https://github.com/dee
 
 > `optional` **features**: [`AudioFeatures`](AudioFeatures.md)
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:87](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L87)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:87](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L87)
 
 ***
 
@@ -56,7 +56,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:87](https://github.com/dee
 
 > **id**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:82](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L82)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:82](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L82)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:82](https://github.com/dee
 
 > **rms**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:84](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L84)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:84](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L84)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:84](https://github.com/dee
 
 > `optional` **samples**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:95](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L95)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:95](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L95)
 
 ***
 
@@ -80,7 +80,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:95](https://github.com/dee
 
 > **silent**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:86](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L86)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:86](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L86)
 
 ***
 
@@ -88,7 +88,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:86](https://github.com/dee
 
 > `optional` **speech**: [`SpeechFeatures`](SpeechFeatures.md)
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:88](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L88)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:88](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L88)
 
 ***
 
@@ -96,7 +96,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:88](https://github.com/dee
 
 > `optional` **startPosition**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:92](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L92)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:92](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L92)
 
 ***
 
@@ -104,4 +104,4 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:92](https://github.com/dee
 
 > `optional` **startTime**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:89](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L89)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:89](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L89)

--- a/documentation_site/docs/api-reference/API/interfaces/DecodingConfig.md
+++ b/documentation_site/docs/api-reference/API/interfaces/DecodingConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: DecodingConfig
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:8](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L8)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:8](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L8)
 
 Represents the configuration for decoding audio data.
 
@@ -16,7 +16,7 @@ Represents the configuration for decoding audio data.
 
 > `optional` **normalizeAudio**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:16](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L16)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:16](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L16)
 
 Whether to normalize audio levels (Android and Web)
 
@@ -26,7 +26,7 @@ Whether to normalize audio levels (Android and Web)
 
 > `optional` **targetBitDepth**: [`BitDepth`](../type-aliases/BitDepth.md)
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:14](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L14)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:14](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L14)
 
 Target bit depth (Android and Web)
 
@@ -36,7 +36,7 @@ Target bit depth (Android and Web)
 
 > `optional` **targetChannels**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:12](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L12)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:12](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L12)
 
 Target number of channels (Android and Web)
 
@@ -46,6 +46,6 @@ Target number of channels (Android and Web)
 
 > `optional` **targetSampleRate**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:10](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L10)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:10](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L10)
 
 Target sample rate for decoded audio (Android and Web)

--- a/documentation_site/docs/api-reference/API/interfaces/ExtractAudioDataOptions.md
+++ b/documentation_site/docs/api-reference/API/interfaces/ExtractAudioDataOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: ExtractAudioDataOptions
 
-Defined in: [src/ExpoAudioStream.types.ts:428](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L428)
+Defined in: [src/ExpoAudioStream.types.ts:444](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L444)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/ExpoAudioStream.types.ts:428](https://github.com/deeeed/expo-au
 
 > `optional` **computeChecksum**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:448](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L448)
+Defined in: [src/ExpoAudioStream.types.ts:464](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L464)
 
 Compute the checksum of the PCM data
 
@@ -24,7 +24,7 @@ Compute the checksum of the PCM data
 
 > `optional` **decodingOptions**: [`DecodingConfig`](DecodingConfig.md)
 
-Defined in: [src/ExpoAudioStream.types.ts:450](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L450)
+Defined in: [src/ExpoAudioStream.types.ts:466](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L466)
 
 Target config for the normalized audio (Android and Web)
 
@@ -34,7 +34,7 @@ Target config for the normalized audio (Android and Web)
 
 > `optional` **endTimeMs**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:434](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L434)
+Defined in: [src/ExpoAudioStream.types.ts:450](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L450)
 
 End time in milliseconds (for time-based range)
 
@@ -44,7 +44,7 @@ End time in milliseconds (for time-based range)
 
 > **fileUri**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:430](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L430)
+Defined in: [src/ExpoAudioStream.types.ts:446](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L446)
 
 URI of the audio file to extract data from
 
@@ -54,7 +54,7 @@ URI of the audio file to extract data from
 
 > `optional` **includeBase64Data**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:442](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L442)
+Defined in: [src/ExpoAudioStream.types.ts:458](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L458)
 
 Include base64 encoded string representation of the audio data
 
@@ -64,7 +64,7 @@ Include base64 encoded string representation of the audio data
 
 > `optional` **includeNormalizedData**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:440](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L440)
+Defined in: [src/ExpoAudioStream.types.ts:456](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L456)
 
 Include normalized audio data in [-1, 1] range
 
@@ -74,7 +74,7 @@ Include normalized audio data in [-1, 1] range
 
 > `optional` **includeWavHeader**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:444](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L444)
+Defined in: [src/ExpoAudioStream.types.ts:460](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L460)
 
 Include WAV header in the PCM data (makes it a valid WAV file)
 
@@ -84,7 +84,7 @@ Include WAV header in the PCM data (makes it a valid WAV file)
 
 > `optional` **length**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:438](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L438)
+Defined in: [src/ExpoAudioStream.types.ts:454](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L454)
 
 Length in bytes to extract (for byte-based range)
 
@@ -94,7 +94,7 @@ Length in bytes to extract (for byte-based range)
 
 > `optional` **logger**: [`ConsoleLike`](../type-aliases/ConsoleLike.md)
 
-Defined in: [src/ExpoAudioStream.types.ts:446](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L446)
+Defined in: [src/ExpoAudioStream.types.ts:462](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L462)
 
 Logger for debugging - can pass console directly.
 
@@ -104,7 +104,7 @@ Logger for debugging - can pass console directly.
 
 > `optional` **position**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:436](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L436)
+Defined in: [src/ExpoAudioStream.types.ts:452](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L452)
 
 Start position in bytes (for byte-based range)
 
@@ -114,6 +114,6 @@ Start position in bytes (for byte-based range)
 
 > `optional` **startTimeMs**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:432](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L432)
+Defined in: [src/ExpoAudioStream.types.ts:448](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L448)
 
 Start time in milliseconds (for time-based range)

--- a/documentation_site/docs/api-reference/API/interfaces/ExtractMelSpectrogramOptions.md
+++ b/documentation_site/docs/api-reference/API/interfaces/ExtractMelSpectrogramOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: ExtractMelSpectrogramOptions
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:173](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L173)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:173](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L173)
 
 **`Experimental`**
 
@@ -21,7 +21,7 @@ The API may change in future versions.
 
 > `optional` **arrayBuffer**: `ArrayBuffer`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:175](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L175)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:175](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L175)
 
 **`Experimental`**
 
@@ -31,7 +31,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:175](https://github.com/de
 
 > `optional` **decodingOptions**: [`DecodingConfig`](DecodingConfig.md)
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:184](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L184)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:184](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L184)
 
 **`Experimental`**
 
@@ -41,7 +41,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:184](https://github.com/de
 
 > `optional` **endTimeMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:186](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L186)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:186](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L186)
 
 **`Experimental`**
 
@@ -51,7 +51,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:186](https://github.com/de
 
 > `optional` **fileUri**: `string`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:174](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L174)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:174](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L174)
 
 **`Experimental`**
 
@@ -61,7 +61,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:174](https://github.com/de
 
 > `optional` **fMax**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:180](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L180)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:180](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L180)
 
 **`Experimental`**
 
@@ -71,7 +71,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:180](https://github.com/de
 
 > `optional` **fMin**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:179](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L179)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:179](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L179)
 
 **`Experimental`**
 
@@ -81,7 +81,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:179](https://github.com/de
 
 > **hopLengthMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:177](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L177)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:177](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L177)
 
 **`Experimental`**
 
@@ -91,7 +91,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:177](https://github.com/de
 
 > `optional` **logger**: [`ConsoleLike`](../type-aliases/ConsoleLike.md)
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:187](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L187)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:187](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L187)
 
 **`Experimental`**
 
@@ -101,7 +101,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:187](https://github.com/de
 
 > `optional` **logScale**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:183](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L183)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:183](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L183)
 
 **`Experimental`**
 
@@ -111,7 +111,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:183](https://github.com/de
 
 > **nMels**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:178](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L178)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:178](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L178)
 
 **`Experimental`**
 
@@ -121,7 +121,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:178](https://github.com/de
 
 > `optional` **normalize**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:182](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L182)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:182](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L182)
 
 **`Experimental`**
 
@@ -131,7 +131,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:182](https://github.com/de
 
 > `optional` **startTimeMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:185](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L185)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:185](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L185)
 
 **`Experimental`**
 
@@ -141,7 +141,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:185](https://github.com/de
 
 > **windowSizeMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:176](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L176)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:176](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L176)
 
 **`Experimental`**
 
@@ -151,6 +151,6 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:176](https://github.com/de
 
 > `optional` **windowType**: `"hann"` \| `"hamming"`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:181](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L181)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:181](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L181)
 
 **`Experimental`**

--- a/documentation_site/docs/api-reference/API/interfaces/ExtractedAudioData.md
+++ b/documentation_site/docs/api-reference/API/interfaces/ExtractedAudioData.md
@@ -6,7 +6,7 @@
 
 # Interface: ExtractedAudioData
 
-Defined in: [src/ExpoAudioStream.types.ts:453](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L453)
+Defined in: [src/ExpoAudioStream.types.ts:469](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L469)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/ExpoAudioStream.types.ts:453](https://github.com/deeeed/expo-au
 
 > `optional` **base64Data**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:459](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L459)
+Defined in: [src/ExpoAudioStream.types.ts:475](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L475)
 
 Base64 encoded string representation of the audio data (when includeBase64Data is true)
 
@@ -24,7 +24,7 @@ Base64 encoded string representation of the audio data (when includeBase64Data i
 
 > **bitDepth**: [`BitDepth`](../type-aliases/BitDepth.md)
 
-Defined in: [src/ExpoAudioStream.types.ts:465](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L465)
+Defined in: [src/ExpoAudioStream.types.ts:481](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L481)
 
 Bits per sample (8, 16, or 32)
 
@@ -34,7 +34,7 @@ Bits per sample (8, 16, or 32)
 
 > **channels**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:463](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L463)
+Defined in: [src/ExpoAudioStream.types.ts:479](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L479)
 
 Number of audio channels (1 for mono, 2 for stereo)
 
@@ -44,7 +44,7 @@ Number of audio channels (1 for mono, 2 for stereo)
 
 > `optional` **checksum**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:475](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L475)
+Defined in: [src/ExpoAudioStream.types.ts:491](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L491)
 
 CRC32 Checksum of PCM data
 
@@ -54,7 +54,7 @@ CRC32 Checksum of PCM data
 
 > **durationMs**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:467](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L467)
+Defined in: [src/ExpoAudioStream.types.ts:483](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L483)
 
 Duration of the audio in milliseconds
 
@@ -64,7 +64,7 @@ Duration of the audio in milliseconds
 
 > **format**: `"pcm_32bit"` \| `"pcm_16bit"` \| `"pcm_8bit"`
 
-Defined in: [src/ExpoAudioStream.types.ts:469](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L469)
+Defined in: [src/ExpoAudioStream.types.ts:485](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L485)
 
 PCM format identifier (e.g., "pcm_16bit")
 
@@ -74,7 +74,7 @@ PCM format identifier (e.g., "pcm_16bit")
 
 > `optional` **hasWavHeader**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:473](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L473)
+Defined in: [src/ExpoAudioStream.types.ts:489](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L489)
 
 Whether the pcmData includes a WAV header
 
@@ -84,7 +84,7 @@ Whether the pcmData includes a WAV header
 
 > `optional` **normalizedData**: `Float32Array`
 
-Defined in: [src/ExpoAudioStream.types.ts:457](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L457)
+Defined in: [src/ExpoAudioStream.types.ts:473](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L473)
 
 Normalized audio data in [-1, 1] range (when includeNormalizedData is true)
 
@@ -94,7 +94,7 @@ Normalized audio data in [-1, 1] range (when includeNormalizedData is true)
 
 > **pcmData**: `Uint8Array`
 
-Defined in: [src/ExpoAudioStream.types.ts:455](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L455)
+Defined in: [src/ExpoAudioStream.types.ts:471](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L471)
 
 Raw PCM audio data
 
@@ -104,7 +104,7 @@ Raw PCM audio data
 
 > **sampleRate**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:461](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L461)
+Defined in: [src/ExpoAudioStream.types.ts:477](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L477)
 
 Sample rate in Hz (e.g., 44100, 48000)
 
@@ -114,6 +114,6 @@ Sample rate in Hz (e.g., 44100, 48000)
 
 > **samples**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:471](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L471)
+Defined in: [src/ExpoAudioStream.types.ts:487](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L487)
 
 Total number of audio samples per channel

--- a/documentation_site/docs/api-reference/API/interfaces/IOSConfig.md
+++ b/documentation_site/docs/api-reference/API/interfaces/IOSConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: IOSConfig
 
-Defined in: [src/ExpoAudioStream.types.ts:205](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L205)
+Defined in: [src/ExpoAudioStream.types.ts:205](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L205)
 
 ## Properties
 
@@ -14,6 +14,6 @@ Defined in: [src/ExpoAudioStream.types.ts:205](https://github.com/deeeed/expo-au
 
 > `optional` **audioSession**: [`AudioSessionConfig`](AudioSessionConfig.md)
 
-Defined in: [src/ExpoAudioStream.types.ts:207](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L207)
+Defined in: [src/ExpoAudioStream.types.ts:207](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L207)
 
 Configuration for the iOS audio session

--- a/documentation_site/docs/api-reference/API/interfaces/MelSpectrogram.md
+++ b/documentation_site/docs/api-reference/API/interfaces/MelSpectrogram.md
@@ -6,7 +6,7 @@
 
 # Interface: MelSpectrogram
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:196](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L196)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:196](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L196)
 
 **`Experimental`**
 
@@ -21,7 +21,7 @@ The API may change in future versions.
 
 > **durationMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:201](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L201)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:201](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L201)
 
 **`Experimental`**
 
@@ -31,7 +31,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:201](https://github.com/de
 
 > **nMels**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:199](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L199)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:199](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L199)
 
 **`Experimental`**
 
@@ -41,7 +41,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:199](https://github.com/de
 
 > **sampleRate**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:198](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L198)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:198](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L198)
 
 **`Experimental`**
 
@@ -51,7 +51,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:198](https://github.com/de
 
 > **spectrogram**: `number`[][]
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:197](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L197)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:197](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L197)
 
 **`Experimental`**
 
@@ -61,6 +61,6 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:197](https://github.com/de
 
 > **timeSteps**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:200](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L200)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:200](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L200)
 
 **`Experimental`**

--- a/documentation_site/docs/api-reference/API/interfaces/NotificationAction.md
+++ b/documentation_site/docs/api-reference/API/interfaces/NotificationAction.md
@@ -6,7 +6,7 @@
 
 # Interface: NotificationAction
 
-Defined in: [src/ExpoAudioStream.types.ts:402](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L402)
+Defined in: [src/ExpoAudioStream.types.ts:418](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L418)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/ExpoAudioStream.types.ts:402](https://github.com/deeeed/expo-au
 
 > `optional` **icon**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:410](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L410)
+Defined in: [src/ExpoAudioStream.types.ts:426](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L426)
 
 Icon to be displayed for the action (Android only)
 
@@ -24,7 +24,7 @@ Icon to be displayed for the action (Android only)
 
 > **identifier**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:407](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L407)
+Defined in: [src/ExpoAudioStream.types.ts:423](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L423)
 
 Unique identifier for the action
 
@@ -34,6 +34,6 @@ Unique identifier for the action
 
 > **title**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:404](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L404)
+Defined in: [src/ExpoAudioStream.types.ts:420](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L420)
 
 Display title for the action

--- a/documentation_site/docs/api-reference/API/interfaces/NotificationConfig.md
+++ b/documentation_site/docs/api-reference/API/interfaces/NotificationConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: NotificationConfig
 
-Defined in: [src/ExpoAudioStream.types.ts:355](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L355)
+Defined in: [src/ExpoAudioStream.types.ts:371](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L371)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/ExpoAudioStream.types.ts:355](https://github.com/deeeed/expo-au
 
 > `optional` **android**: `object`
 
-Defined in: [src/ExpoAudioStream.types.ts:366](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L366)
+Defined in: [src/ExpoAudioStream.types.ts:382](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L382)
 
 Android-specific notification configuration
 
@@ -62,7 +62,7 @@ Unique identifier for this notification
 
 #### priority?
 
-> `optional` **priority**: `"min"` \| `"low"` \| `"default"` \| `"high"` \| `"max"`
+> `optional` **priority**: `"default"` \| `"min"` \| `"low"` \| `"high"` \| `"max"`
 
 Priority of the notification (affects how it's displayed)
 
@@ -78,7 +78,7 @@ Configuration for the waveform visualization in the notification
 
 > `optional` **icon**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:363](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L363)
+Defined in: [src/ExpoAudioStream.types.ts:379](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L379)
 
 Icon to be displayed in the notification (resource name or URI)
 
@@ -88,7 +88,7 @@ Icon to be displayed in the notification (resource name or URI)
 
 > `optional` **ios**: `object`
 
-Defined in: [src/ExpoAudioStream.types.ts:396](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L396)
+Defined in: [src/ExpoAudioStream.types.ts:412](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L412)
 
 iOS-specific notification configuration
 
@@ -104,7 +104,7 @@ Identifier for the notification category (used for grouping similar notification
 
 > `optional` **text**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:360](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L360)
+Defined in: [src/ExpoAudioStream.types.ts:376](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L376)
 
 Main text content of the notification
 
@@ -114,6 +114,6 @@ Main text content of the notification
 
 > `optional` **title**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:357](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L357)
+Defined in: [src/ExpoAudioStream.types.ts:373](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L373)
 
 Title of the notification

--- a/documentation_site/docs/api-reference/API/interfaces/PreviewOptions.md
+++ b/documentation_site/docs/api-reference/API/interfaces/PreviewOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: PreviewOptions
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:144](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L144)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:144](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L144)
 
 Options for generating a quick preview of audio waveform.
 This is optimized for UI rendering with a specified number of points.
@@ -21,7 +21,7 @@ This is optimized for UI rendering with a specified number of points.
 
 > `optional` **decodingOptions**: [`DecodingConfig`](DecodingConfig.md)
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:164](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L164)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:164](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L164)
 
 Optional configuration for decoding the audio file.
 Defaults to:
@@ -36,7 +36,7 @@ Defaults to:
 
 > `optional` **endTimeMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:137](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L137)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:137](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L137)
 
 End time in milliseconds
 
@@ -50,7 +50,7 @@ End time in milliseconds
 
 > **fileUri**: `string`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:146](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L146)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:146](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L146)
 
 URI of the audio file to analyze
 
@@ -60,7 +60,7 @@ URI of the audio file to analyze
 
 > `optional` **logger**: [`ConsoleLike`](../type-aliases/ConsoleLike.md)
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:155](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L155)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:155](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L155)
 
 Optional logger for debugging.
 
@@ -70,7 +70,7 @@ Optional logger for debugging.
 
 > `optional` **numberOfPoints**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:151](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L151)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:151](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L151)
 
 Total number of points to generate for the preview.
 
@@ -86,7 +86,7 @@ Total number of points to generate for the preview.
 
 > `optional` **startTimeMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:135](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L135)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:135](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L135)
 
 Start time in milliseconds
 

--- a/documentation_site/docs/api-reference/API/interfaces/RecordingConfig.md
+++ b/documentation_site/docs/api-reference/API/interfaces/RecordingConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: RecordingConfig
 
-Defined in: [src/ExpoAudioStream.types.ts:281](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L281)
+Defined in: [src/ExpoAudioStream.types.ts:294](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L294)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/ExpoAudioStream.types.ts:281](https://github.com/deeeed/expo-au
 
 > `optional` **autoResumeAfterInterruption**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:338](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L338)
+Defined in: [src/ExpoAudioStream.types.ts:354](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L354)
 
 Whether to automatically resume recording after an interruption (default is false)
 
@@ -24,7 +24,7 @@ Whether to automatically resume recording after an interruption (default is fals
 
 > `optional` **channels**: `1` \| `2`
 
-Defined in: [src/ExpoAudioStream.types.ts:286](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L286)
+Defined in: [src/ExpoAudioStream.types.ts:299](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L299)
 
 Number of audio channels (1 for mono, 2 for stereo)
 
@@ -34,7 +34,7 @@ Number of audio channels (1 for mono, 2 for stereo)
 
 > `optional` **compression**: `object`
 
-Defined in: [src/ExpoAudioStream.types.ts:328](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L328)
+Defined in: [src/ExpoAudioStream.types.ts:344](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L344)
 
 Configuration for audio compression
 
@@ -52,7 +52,7 @@ Enable audio compression
 
 #### format
 
-> **format**: `"opus"` \| `"aac"`
+> **format**: `"aac"` \| `"opus"`
 
 Format for compression (aac or opus)
 
@@ -62,7 +62,7 @@ Format for compression (aac or opus)
 
 > `optional` **deviceDisconnectionBehavior**: [`DeviceDisconnectionBehaviorType`](../type-aliases/DeviceDisconnectionBehaviorType.md)
 
-Defined in: [src/ExpoAudioStream.types.ts:352](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L352)
+Defined in: [src/ExpoAudioStream.types.ts:368](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L368)
 
 How to handle device disconnection during recording
 
@@ -72,7 +72,7 @@ How to handle device disconnection during recording
 
 > `optional` **deviceId**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:349](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L349)
+Defined in: [src/ExpoAudioStream.types.ts:365](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L365)
 
 ID of the device to use for recording (if not specified, uses default)
 
@@ -82,7 +82,7 @@ ID of the device to use for recording (if not specified, uses default)
 
 > `optional` **enableProcessing**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:310](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L310)
+Defined in: [src/ExpoAudioStream.types.ts:323](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L323)
 
 Enable audio processing (default is false)
 
@@ -92,7 +92,7 @@ Enable audio processing (default is false)
 
 > `optional` **encoding**: [`EncodingType`](../type-aliases/EncodingType.md)
 
-Defined in: [src/ExpoAudioStream.types.ts:289](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L289)
+Defined in: [src/ExpoAudioStream.types.ts:302](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L302)
 
 Encoding type for the recording (pcm_32bit, pcm_16bit, pcm_8bit)
 
@@ -102,7 +102,7 @@ Encoding type for the recording (pcm_32bit, pcm_16bit, pcm_8bit)
 
 > `optional` **features**: [`AudioFeaturesOptions`](AudioFeaturesOptions.md)
 
-Defined in: [src/ExpoAudioStream.types.ts:319](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L319)
+Defined in: [src/ExpoAudioStream.types.ts:335](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L335)
 
 Feature options to extract during audio processing
 
@@ -112,7 +112,7 @@ Feature options to extract during audio processing
 
 > `optional` **filename**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:346](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L346)
+Defined in: [src/ExpoAudioStream.types.ts:362](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L362)
 
 Optional filename for the recording (uses UUID if not provided)
 
@@ -122,7 +122,7 @@ Optional filename for the recording (uses UUID if not provided)
 
 > `optional` **interval**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:292](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L292)
+Defined in: [src/ExpoAudioStream.types.ts:305](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L305)
 
 Interval in milliseconds at which to emit recording data
 
@@ -132,7 +132,7 @@ Interval in milliseconds at which to emit recording data
 
 > `optional` **intervalAnalysis**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:295](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L295)
+Defined in: [src/ExpoAudioStream.types.ts:308](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L308)
 
 Interval in milliseconds at which to emit analysis data
 
@@ -142,7 +142,7 @@ Interval in milliseconds at which to emit analysis data
 
 > `optional` **ios**: [`IOSConfig`](IOSConfig.md)
 
-Defined in: [src/ExpoAudioStream.types.ts:313](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L313)
+Defined in: [src/ExpoAudioStream.types.ts:326](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L326)
 
 iOS-specific configuration
 
@@ -152,7 +152,7 @@ iOS-specific configuration
 
 > `optional` **keepAwake**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:298](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L298)
+Defined in: [src/ExpoAudioStream.types.ts:311](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L311)
 
 Keep the device awake while recording (default is false)
 
@@ -162,7 +162,7 @@ Keep the device awake while recording (default is false)
 
 > `optional` **notification**: [`NotificationConfig`](NotificationConfig.md)
 
-Defined in: [src/ExpoAudioStream.types.ts:307](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L307)
+Defined in: [src/ExpoAudioStream.types.ts:320](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L320)
 
 Configuration for the notification
 
@@ -172,7 +172,7 @@ Configuration for the notification
 
 > `optional` **onAudioAnalysis**: (`_`) => `Promise`\<`void`\>
 
-Defined in: [src/ExpoAudioStream.types.ts:325](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L325)
+Defined in: [src/ExpoAudioStream.types.ts:341](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L341)
 
 Callback function to handle audio features extraction results
 
@@ -192,7 +192,7 @@ Callback function to handle audio features extraction results
 
 > `optional` **onAudioStream**: (`_`) => `Promise`\<`void`\>
 
-Defined in: [src/ExpoAudioStream.types.ts:322](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L322)
+Defined in: [src/ExpoAudioStream.types.ts:338](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L338)
 
 Callback function to handle audio stream data
 
@@ -212,7 +212,7 @@ Callback function to handle audio stream data
 
 > `optional` **onRecordingInterrupted**: (`_`) => `void`
 
-Defined in: [src/ExpoAudioStream.types.ts:341](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L341)
+Defined in: [src/ExpoAudioStream.types.ts:357](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L357)
 
 Optional callback to handle recording interruptions
 
@@ -232,7 +232,7 @@ Optional callback to handle recording interruptions
 
 > `optional` **outputDirectory**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:344](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L344)
+Defined in: [src/ExpoAudioStream.types.ts:360](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L360)
 
 Optional directory path where output files will be saved
 
@@ -242,7 +242,7 @@ Optional directory path where output files will be saved
 
 > `optional` **sampleRate**: [`SampleRate`](../type-aliases/SampleRate.md)
 
-Defined in: [src/ExpoAudioStream.types.ts:283](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L283)
+Defined in: [src/ExpoAudioStream.types.ts:296](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L296)
 
 Sample rate for recording in Hz (16000, 44100, or 48000)
 
@@ -252,7 +252,7 @@ Sample rate for recording in Hz (16000, 44100, or 48000)
 
 > `optional` **segmentDurationMs**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:316](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L316)
+Defined in: [src/ExpoAudioStream.types.ts:332](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L332)
 
 Duration of each segment in milliseconds for analysis (default: 100)
 
@@ -262,7 +262,7 @@ Duration of each segment in milliseconds for analysis (default: 100)
 
 > `optional` **showNotification**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:301](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L301)
+Defined in: [src/ExpoAudioStream.types.ts:314](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L314)
 
 Show a notification during recording (default is false)
 
@@ -272,6 +272,16 @@ Show a notification during recording (default is false)
 
 > `optional` **showWaveformInNotification**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:304](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L304)
+Defined in: [src/ExpoAudioStream.types.ts:317](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L317)
 
 Show waveform in the notification (Android only, when showNotification is true)
+
+***
+
+### web?
+
+> `optional` **web**: [`WebConfig`](WebConfig.md)
+
+Defined in: [src/ExpoAudioStream.types.ts:329](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L329)
+
+Web-specific configuration options

--- a/documentation_site/docs/api-reference/API/interfaces/RecordingInterruptionEvent.md
+++ b/documentation_site/docs/api-reference/API/interfaces/RecordingInterruptionEvent.md
@@ -6,7 +6,7 @@
 
 # Interface: RecordingInterruptionEvent
 
-Defined in: [src/ExpoAudioStream.types.ts:232](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L232)
+Defined in: [src/ExpoAudioStream.types.ts:245](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L245)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/ExpoAudioStream.types.ts:232](https://github.com/deeeed/expo-au
 
 > **isPaused**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:236](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L236)
+Defined in: [src/ExpoAudioStream.types.ts:249](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L249)
 
 Indicates whether the recording is paused due to the interruption
 
@@ -24,6 +24,6 @@ Indicates whether the recording is paused due to the interruption
 
 > **reason**: [`RecordingInterruptionReason`](../type-aliases/RecordingInterruptionReason.md)
 
-Defined in: [src/ExpoAudioStream.types.ts:234](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L234)
+Defined in: [src/ExpoAudioStream.types.ts:247](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L247)
 
 The reason for the recording interruption

--- a/documentation_site/docs/api-reference/API/interfaces/SpeechFeatures.md
+++ b/documentation_site/docs/api-reference/API/interfaces/SpeechFeatures.md
@@ -6,7 +6,7 @@
 
 # Interface: SpeechFeatures
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:22](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L22)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:22](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L22)
 
 Represents speech-related features extracted from audio.
 
@@ -16,7 +16,7 @@ Represents speech-related features extracted from audio.
 
 > **isActive**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:23](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L23)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:23](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L23)
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:23](https://github.com/dee
 
 > `optional` **speakerId**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:24](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L24)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:24](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L24)

--- a/documentation_site/docs/api-reference/API/interfaces/StartRecordingResult.md
+++ b/documentation_site/docs/api-reference/API/interfaces/StartRecordingResult.md
@@ -6,7 +6,7 @@
 
 # Interface: StartRecordingResult
 
-Defined in: [src/ExpoAudioStream.types.ts:129](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L129)
+Defined in: [src/ExpoAudioStream.types.ts:129](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L129)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/ExpoAudioStream.types.ts:129](https://github.com/deeeed/expo-au
 
 > `optional` **bitDepth**: [`BitDepth`](../type-aliases/BitDepth.md)
 
-Defined in: [src/ExpoAudioStream.types.ts:137](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L137)
+Defined in: [src/ExpoAudioStream.types.ts:137](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L137)
 
 Bit depth of the audio (8, 16, or 32 bits)
 
@@ -24,7 +24,7 @@ Bit depth of the audio (8, 16, or 32 bits)
 
 > `optional` **channels**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:135](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L135)
+Defined in: [src/ExpoAudioStream.types.ts:135](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L135)
 
 Number of audio channels (1 for mono, 2 for stereo)
 
@@ -34,7 +34,7 @@ Number of audio channels (1 for mono, 2 for stereo)
 
 > `optional` **compression**: [`CompressionInfo`](CompressionInfo.md) & `object`
 
-Defined in: [src/ExpoAudioStream.types.ts:141](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L141)
+Defined in: [src/ExpoAudioStream.types.ts:141](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L141)
 
 Information about compression if enabled, including the URI to the compressed file
 
@@ -52,7 +52,7 @@ URI to the compressed audio file
 
 > **fileUri**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:131](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L131)
+Defined in: [src/ExpoAudioStream.types.ts:131](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L131)
 
 URI to the file being recorded
 
@@ -62,7 +62,7 @@ URI to the file being recorded
 
 > **mimeType**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:133](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L133)
+Defined in: [src/ExpoAudioStream.types.ts:133](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L133)
 
 MIME type of the recording
 
@@ -72,6 +72,6 @@ MIME type of the recording
 
 > `optional` **sampleRate**: [`SampleRate`](../type-aliases/SampleRate.md)
 
-Defined in: [src/ExpoAudioStream.types.ts:139](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L139)
+Defined in: [src/ExpoAudioStream.types.ts:139](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L139)
 
 Sample rate of the audio in Hz

--- a/documentation_site/docs/api-reference/API/interfaces/TimeRange.md
+++ b/documentation_site/docs/api-reference/API/interfaces/TimeRange.md
@@ -6,7 +6,7 @@
 
 # Interface: TimeRange
 
-Defined in: [src/ExpoAudioStream.types.ts:566](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L566)
+Defined in: [src/ExpoAudioStream.types.ts:582](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L582)
 
 Defines a time range in milliseconds for trimming operations.
 
@@ -16,7 +16,7 @@ Defines a time range in milliseconds for trimming operations.
 
 > **endTimeMs**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:575](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L575)
+Defined in: [src/ExpoAudioStream.types.ts:591](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L591)
 
 The end time of the range in milliseconds.
 
@@ -26,6 +26,6 @@ The end time of the range in milliseconds.
 
 > **startTimeMs**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:570](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L570)
+Defined in: [src/ExpoAudioStream.types.ts:586](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L586)
 
 The start time of the range in milliseconds.

--- a/documentation_site/docs/api-reference/API/interfaces/TranscriberData.md
+++ b/documentation_site/docs/api-reference/API/interfaces/TranscriberData.md
@@ -6,7 +6,7 @@
 
 # Interface: TranscriberData
 
-Defined in: [src/ExpoAudioStream.types.ts:84](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L84)
+Defined in: [src/ExpoAudioStream.types.ts:84](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L84)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/ExpoAudioStream.types.ts:84](https://github.com/deeeed/expo-aud
 
 > **chunks**: [`Chunk`](Chunk.md)[]
 
-Defined in: [src/ExpoAudioStream.types.ts:96](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L96)
+Defined in: [src/ExpoAudioStream.types.ts:96](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L96)
 
 Array of transcribed text chunks with timestamps
 
@@ -24,7 +24,7 @@ Array of transcribed text chunks with timestamps
 
 > **endTime**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:94](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L94)
+Defined in: [src/ExpoAudioStream.types.ts:94](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L94)
 
 End time of the transcription in milliseconds
 
@@ -34,7 +34,7 @@ End time of the transcription in milliseconds
 
 > **id**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:86](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L86)
+Defined in: [src/ExpoAudioStream.types.ts:86](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L86)
 
 Unique identifier for the transcription
 
@@ -44,7 +44,7 @@ Unique identifier for the transcription
 
 > **isBusy**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:88](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L88)
+Defined in: [src/ExpoAudioStream.types.ts:88](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L88)
 
 Indicates if the transcriber is currently processing
 
@@ -54,7 +54,7 @@ Indicates if the transcriber is currently processing
 
 > **startTime**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:92](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L92)
+Defined in: [src/ExpoAudioStream.types.ts:92](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L92)
 
 Start time of the transcription in milliseconds
 
@@ -64,6 +64,6 @@ Start time of the transcription in milliseconds
 
 > **text**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:90](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L90)
+Defined in: [src/ExpoAudioStream.types.ts:90](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L90)
 
 Complete transcribed text

--- a/documentation_site/docs/api-reference/API/interfaces/TrimAudioOptions.md
+++ b/documentation_site/docs/api-reference/API/interfaces/TrimAudioOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: TrimAudioOptions
 
-Defined in: [src/ExpoAudioStream.types.ts:581](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L581)
+Defined in: [src/ExpoAudioStream.types.ts:597](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L597)
 
 Options for configuring the audio trimming operation.
 
@@ -16,7 +16,7 @@ Options for configuring the audio trimming operation.
 
 > `optional` **decodingOptions**: [`DecodingConfig`](DecodingConfig.md)
 
-Defined in: [src/ExpoAudioStream.types.ts:661](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L661)
+Defined in: [src/ExpoAudioStream.types.ts:677](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L677)
 
 Options for decoding the input audio file.
 - See `DecodingConfig` for details.
@@ -27,7 +27,7 @@ Options for decoding the input audio file.
 
 > `optional` **endTimeMs**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:613](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L613)
+Defined in: [src/ExpoAudioStream.types.ts:629](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L629)
 
 The end time in milliseconds for the `'single'` mode.
 - If not provided, trimming extends to the end of the audio.
@@ -38,7 +38,7 @@ The end time in milliseconds for the `'single'` mode.
 
 > **fileUri**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:585](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L585)
+Defined in: [src/ExpoAudioStream.types.ts:601](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L601)
 
 The URI of the audio file to trim.
 
@@ -48,7 +48,7 @@ The URI of the audio file to trim.
 
 > `optional` **mode**: `"single"` \| `"keep"` \| `"remove"`
 
-Defined in: [src/ExpoAudioStream.types.ts:594](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L594)
+Defined in: [src/ExpoAudioStream.types.ts:610](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L610)
 
 The mode of trimming to apply.
 - `'single'`: Trims the audio to a single range defined by `startTimeMs` and `endTimeMs`.
@@ -67,7 +67,7 @@ The mode of trimming to apply.
 
 > `optional` **outputFileName**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:618](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L618)
+Defined in: [src/ExpoAudioStream.types.ts:634](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L634)
 
 The name of the output file. If not provided, a default name will be generated.
 
@@ -77,7 +77,7 @@ The name of the output file. If not provided, a default name will be generated.
 
 > `optional` **outputFormat**: `object`
 
-Defined in: [src/ExpoAudioStream.types.ts:623](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L623)
+Defined in: [src/ExpoAudioStream.types.ts:639](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L639)
 
 Configuration for the output audio format.
 
@@ -104,7 +104,7 @@ The number of channels in the output audio (e.g., 1 for mono, 2 for stereo).
 
 #### format
 
-> **format**: `"opus"` \| `"wav"` \| `"aac"`
+> **format**: `"aac"` \| `"opus"` \| `"wav"`
 
 The format of the output audio file.
 - `'wav'`: Waveform Audio File Format (uncompressed).
@@ -124,7 +124,7 @@ The sample rate of the output audio in Hertz (Hz).
 
 > `optional` **ranges**: [`TimeRange`](TimeRange.md)[]
 
-Defined in: [src/ExpoAudioStream.types.ts:601](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L601)
+Defined in: [src/ExpoAudioStream.types.ts:617](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L617)
 
 An array of time ranges to keep or remove, depending on the `mode`.
 - Required for `'keep'` and `'remove'` modes.
@@ -136,7 +136,7 @@ An array of time ranges to keep or remove, depending on the `mode`.
 
 > `optional` **startTimeMs**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:607](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L607)
+Defined in: [src/ExpoAudioStream.types.ts:623](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L623)
 
 The start time in milliseconds for the `'single'` mode.
 - If not provided, trimming starts from the beginning of the audio (0 ms).

--- a/documentation_site/docs/api-reference/API/interfaces/TrimAudioResult.md
+++ b/documentation_site/docs/api-reference/API/interfaces/TrimAudioResult.md
@@ -6,7 +6,7 @@
 
 # Interface: TrimAudioResult
 
-Defined in: [src/ExpoAudioStream.types.ts:667](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L667)
+Defined in: [src/ExpoAudioStream.types.ts:683](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L683)
 
 Result of the audio trimming operation.
 
@@ -16,7 +16,7 @@ Result of the audio trimming operation.
 
 > **bitDepth**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:701](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L701)
+Defined in: [src/ExpoAudioStream.types.ts:717](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L717)
 
 The bit depth of the trimmed audio, applicable to PCM formats like `'wav'`.
 
@@ -26,7 +26,7 @@ The bit depth of the trimmed audio, applicable to PCM formats like `'wav'`.
 
 > **channels**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:696](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L696)
+Defined in: [src/ExpoAudioStream.types.ts:712](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L712)
 
 The number of channels in the trimmed audio (e.g., 1 for mono, 2 for stereo).
 
@@ -36,7 +36,7 @@ The number of channels in the trimmed audio (e.g., 1 for mono, 2 for stereo).
 
 > `optional` **compression**: `object`
 
-Defined in: [src/ExpoAudioStream.types.ts:711](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L711)
+Defined in: [src/ExpoAudioStream.types.ts:727](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L727)
 
 Information about compression if the output format is compressed.
 
@@ -64,7 +64,7 @@ The size of the compressed audio file in bytes.
 
 > **durationMs**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:681](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L681)
+Defined in: [src/ExpoAudioStream.types.ts:697](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L697)
 
 The duration of the trimmed audio in milliseconds.
 
@@ -74,7 +74,7 @@ The duration of the trimmed audio in milliseconds.
 
 > **filename**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:676](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L676)
+Defined in: [src/ExpoAudioStream.types.ts:692](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L692)
 
 The filename of the trimmed audio file.
 
@@ -84,7 +84,7 @@ The filename of the trimmed audio file.
 
 > **mimeType**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:706](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L706)
+Defined in: [src/ExpoAudioStream.types.ts:722](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L722)
 
 The MIME type of the trimmed audio file (e.g., `'audio/wav'`, `'audio/mpeg'`).
 
@@ -94,7 +94,7 @@ The MIME type of the trimmed audio file (e.g., `'audio/wav'`, `'audio/mpeg'`).
 
 > `optional` **processingInfo**: `object`
 
-Defined in: [src/ExpoAudioStream.types.ts:731](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L731)
+Defined in: [src/ExpoAudioStream.types.ts:747](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L747)
 
 Information about the processing time.
 
@@ -110,7 +110,7 @@ The time it took to process the audio in milliseconds.
 
 > **sampleRate**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:691](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L691)
+Defined in: [src/ExpoAudioStream.types.ts:707](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L707)
 
 The sample rate of the trimmed audio in Hertz (Hz).
 
@@ -120,7 +120,7 @@ The sample rate of the trimmed audio in Hertz (Hz).
 
 > **size**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:686](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L686)
+Defined in: [src/ExpoAudioStream.types.ts:702](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L702)
 
 The size of the trimmed audio file in bytes.
 
@@ -130,6 +130,6 @@ The size of the trimmed audio file in bytes.
 
 > **uri**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:671](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L671)
+Defined in: [src/ExpoAudioStream.types.ts:687](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L687)
 
 The URI of the trimmed audio file.

--- a/documentation_site/docs/api-reference/API/interfaces/TrimProgressEvent.md
+++ b/documentation_site/docs/api-reference/API/interfaces/TrimProgressEvent.md
@@ -6,7 +6,7 @@
 
 # Interface: TrimProgressEvent
 
-Defined in: [src/ExpoAudioStream.types.ts:546](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L546)
+Defined in: [src/ExpoAudioStream.types.ts:562](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L562)
 
 Represents an event emitted during the trimming process to report progress.
 
@@ -16,7 +16,7 @@ Represents an event emitted during the trimming process to report progress.
 
 > `optional` **bytesProcessed**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:555](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L555)
+Defined in: [src/ExpoAudioStream.types.ts:571](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L571)
 
 The number of bytes that have been processed so far. This is optional and may not be provided in all implementations.
 
@@ -26,7 +26,7 @@ The number of bytes that have been processed so far. This is optional and may no
 
 > **progress**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:550](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L550)
+Defined in: [src/ExpoAudioStream.types.ts:566](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L566)
 
 The percentage of the trimming process that has been completed, ranging from 0 to 100.
 
@@ -36,6 +36,6 @@ The percentage of the trimming process that has been completed, ranging from 0 t
 
 > `optional` **totalBytes**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:560](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L560)
+Defined in: [src/ExpoAudioStream.types.ts:576](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L576)
 
 The total number of bytes to process. This is optional and may not be provided in all implementations.

--- a/documentation_site/docs/api-reference/API/interfaces/UseAudioRecorderState.md
+++ b/documentation_site/docs/api-reference/API/interfaces/UseAudioRecorderState.md
@@ -6,7 +6,7 @@
 
 # Interface: UseAudioRecorderState
 
-Defined in: [src/ExpoAudioStream.types.ts:478](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L478)
+Defined in: [src/ExpoAudioStream.types.ts:494](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L494)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/ExpoAudioStream.types.ts:478](https://github.com/deeeed/expo-au
 
 > `optional` **analysisData**: [`AudioAnalysis`](AudioAnalysis.md)
 
-Defined in: [src/ExpoAudioStream.types.ts:538](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L538)
+Defined in: [src/ExpoAudioStream.types.ts:554](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L554)
 
 Analysis data for the recording if processing was enabled
 
@@ -24,7 +24,7 @@ Analysis data for the recording if processing was enabled
 
 > `optional` **compression**: [`CompressionInfo`](CompressionInfo.md)
 
-Defined in: [src/ExpoAudioStream.types.ts:536](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L536)
+Defined in: [src/ExpoAudioStream.types.ts:552](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L552)
 
 Information about compression if enabled
 
@@ -34,7 +34,7 @@ Information about compression if enabled
 
 > **durationMs**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:532](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L532)
+Defined in: [src/ExpoAudioStream.types.ts:548](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L548)
 
 Duration of the current recording in milliseconds
 
@@ -44,7 +44,7 @@ Duration of the current recording in milliseconds
 
 > **isPaused**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:530](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L530)
+Defined in: [src/ExpoAudioStream.types.ts:546](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L546)
 
 Indicates whether recording is in a paused state
 
@@ -54,7 +54,7 @@ Indicates whether recording is in a paused state
 
 > **isRecording**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:528](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L528)
+Defined in: [src/ExpoAudioStream.types.ts:544](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L544)
 
 Indicates whether recording is currently active
 
@@ -64,7 +64,7 @@ Indicates whether recording is currently active
 
 > `optional` **onRecordingInterrupted**: (`_`) => `void`
 
-Defined in: [src/ExpoAudioStream.types.ts:540](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L540)
+Defined in: [src/ExpoAudioStream.types.ts:556](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L556)
 
 Optional callback to handle recording interruptions
 
@@ -84,7 +84,7 @@ Optional callback to handle recording interruptions
 
 > **pauseRecording**: () => `Promise`\<`void`\>
 
-Defined in: [src/ExpoAudioStream.types.ts:524](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L524)
+Defined in: [src/ExpoAudioStream.types.ts:540](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L540)
 
 Pauses the current recording
 
@@ -98,7 +98,7 @@ Pauses the current recording
 
 > **prepareRecording**: (`_`) => `Promise`\<`void`\>
 
-Defined in: [src/ExpoAudioStream.types.ts:518](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L518)
+Defined in: [src/ExpoAudioStream.types.ts:534](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L534)
 
 Prepares recording with the specified configuration without starting it.
 
@@ -156,7 +156,7 @@ const handleRecordPress = () => startRecording({
 
 > **resumeRecording**: () => `Promise`\<`void`\>
 
-Defined in: [src/ExpoAudioStream.types.ts:526](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L526)
+Defined in: [src/ExpoAudioStream.types.ts:542](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L542)
 
 Resumes a paused recording
 
@@ -170,7 +170,7 @@ Resumes a paused recording
 
 > **size**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:534](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L534)
+Defined in: [src/ExpoAudioStream.types.ts:550](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L550)
 
 Size of the recorded audio in bytes
 
@@ -180,7 +180,7 @@ Size of the recorded audio in bytes
 
 > **startRecording**: (`_`) => `Promise`\<[`StartRecordingResult`](StartRecordingResult.md)\>
 
-Defined in: [src/ExpoAudioStream.types.ts:520](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L520)
+Defined in: [src/ExpoAudioStream.types.ts:536](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L536)
 
 Starts recording with the specified configuration
 
@@ -200,7 +200,7 @@ Starts recording with the specified configuration
 
 > **stopRecording**: () => `Promise`\<`null` \| [`AudioRecording`](AudioRecording.md)\>
 
-Defined in: [src/ExpoAudioStream.types.ts:522](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L522)
+Defined in: [src/ExpoAudioStream.types.ts:538](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L538)
 
 Stops the current recording and returns the recording data
 

--- a/documentation_site/docs/api-reference/API/interfaces/WavFileInfo.md
+++ b/documentation_site/docs/api-reference/API/interfaces/WavFileInfo.md
@@ -6,7 +6,7 @@
 
 # Interface: WavFileInfo
 
-Defined in: [src/utils/getWavFileInfo.ts:26](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L26)
+Defined in: [src/utils/getWavFileInfo.ts:26](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L26)
 
 Interface representing the metadata of a WAV file.
 
@@ -16,7 +16,7 @@ Interface representing the metadata of a WAV file.
 
 > **audioFormatDescription**: `string`
 
-Defined in: [src/utils/getWavFileInfo.ts:32](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L32)
+Defined in: [src/utils/getWavFileInfo.ts:32](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L32)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/utils/getWavFileInfo.ts:32](https://github.com/deeeed/expo-audi
 
 > **bitDepth**: [`BitDepth`](../type-aliases/BitDepth.md)
 
-Defined in: [src/utils/getWavFileInfo.ts:29](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L29)
+Defined in: [src/utils/getWavFileInfo.ts:29](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L29)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [src/utils/getWavFileInfo.ts:29](https://github.com/deeeed/expo-audi
 
 > **blockAlign**: `number`
 
-Defined in: [src/utils/getWavFileInfo.ts:34](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L34)
+Defined in: [src/utils/getWavFileInfo.ts:34](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L34)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [src/utils/getWavFileInfo.ts:34](https://github.com/deeeed/expo-audi
 
 > **byteRate**: `number`
 
-Defined in: [src/utils/getWavFileInfo.ts:33](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L33)
+Defined in: [src/utils/getWavFileInfo.ts:33](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L33)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [src/utils/getWavFileInfo.ts:33](https://github.com/deeeed/expo-audi
 
 > `optional` **comments**: `string`
 
-Defined in: [src/utils/getWavFileInfo.ts:36](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L36)
+Defined in: [src/utils/getWavFileInfo.ts:36](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L36)
 
 ***
 
@@ -56,7 +56,7 @@ Defined in: [src/utils/getWavFileInfo.ts:36](https://github.com/deeeed/expo-audi
 
 > `optional` **compressionType**: `string`
 
-Defined in: [src/utils/getWavFileInfo.ts:37](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L37)
+Defined in: [src/utils/getWavFileInfo.ts:37](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L37)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [src/utils/getWavFileInfo.ts:37](https://github.com/deeeed/expo-audi
 
 > `optional` **creationDateTime**: `string`
 
-Defined in: [src/utils/getWavFileInfo.ts:35](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L35)
+Defined in: [src/utils/getWavFileInfo.ts:35](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L35)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [src/utils/getWavFileInfo.ts:35](https://github.com/deeeed/expo-audi
 
 > **dataChunkOffset**: `number`
 
-Defined in: [src/utils/getWavFileInfo.ts:38](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L38)
+Defined in: [src/utils/getWavFileInfo.ts:38](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L38)
 
 ***
 
@@ -80,7 +80,7 @@ Defined in: [src/utils/getWavFileInfo.ts:38](https://github.com/deeeed/expo-audi
 
 > **durationMs**: `number`
 
-Defined in: [src/utils/getWavFileInfo.ts:31](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L31)
+Defined in: [src/utils/getWavFileInfo.ts:31](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L31)
 
 ***
 
@@ -88,7 +88,7 @@ Defined in: [src/utils/getWavFileInfo.ts:31](https://github.com/deeeed/expo-audi
 
 > **numChannels**: `number`
 
-Defined in: [src/utils/getWavFileInfo.ts:28](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L28)
+Defined in: [src/utils/getWavFileInfo.ts:28](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L28)
 
 ***
 
@@ -96,7 +96,7 @@ Defined in: [src/utils/getWavFileInfo.ts:28](https://github.com/deeeed/expo-audi
 
 > **sampleRate**: [`SampleRate`](../type-aliases/SampleRate.md)
 
-Defined in: [src/utils/getWavFileInfo.ts:27](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L27)
+Defined in: [src/utils/getWavFileInfo.ts:27](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L27)
 
 ***
 
@@ -104,4 +104,4 @@ Defined in: [src/utils/getWavFileInfo.ts:27](https://github.com/deeeed/expo-audi
 
 > **size**: `number`
 
-Defined in: [src/utils/getWavFileInfo.ts:30](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L30)
+Defined in: [src/utils/getWavFileInfo.ts:30](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/getWavFileInfo.ts#L30)

--- a/documentation_site/docs/api-reference/API/interfaces/WavHeaderOptions.md
+++ b/documentation_site/docs/api-reference/API/interfaces/WavHeaderOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: WavHeaderOptions
 
-Defined in: [src/utils/writeWavHeader.ts:6](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/writeWavHeader.ts#L6)
+Defined in: [src/utils/writeWavHeader.ts:6](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/writeWavHeader.ts#L6)
 
 Options for creating a WAV header.
 
@@ -16,7 +16,7 @@ Options for creating a WAV header.
 
 > **bitDepth**: `number`
 
-Defined in: [src/utils/writeWavHeader.ts:14](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/writeWavHeader.ts#L14)
+Defined in: [src/utils/writeWavHeader.ts:14](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/writeWavHeader.ts#L14)
 
 The bit depth of the audio (e.g., 16, 24, or 32).
 
@@ -26,9 +26,19 @@ The bit depth of the audio (e.g., 16, 24, or 32).
 
 > `optional` **buffer**: `ArrayBuffer`
 
-Defined in: [src/utils/writeWavHeader.ts:8](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/writeWavHeader.ts#L8)
+Defined in: [src/utils/writeWavHeader.ts:8](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/writeWavHeader.ts#L8)
 
 Optional buffer containing audio data. If provided, it will be combined with the header.
+
+***
+
+### isFloat?
+
+> `optional` **isFloat**: `boolean`
+
+Defined in: [src/utils/writeWavHeader.ts:16](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/writeWavHeader.ts#L16)
+
+Whether the audio data is in float format (only applies to 32-bit)
 
 ***
 
@@ -36,7 +46,7 @@ Optional buffer containing audio data. If provided, it will be combined with the
 
 > **numChannels**: `number`
 
-Defined in: [src/utils/writeWavHeader.ts:12](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/writeWavHeader.ts#L12)
+Defined in: [src/utils/writeWavHeader.ts:12](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/writeWavHeader.ts#L12)
 
 The number of audio channels (e.g., 1 for mono, 2 for stereo).
 
@@ -46,6 +56,6 @@ The number of audio channels (e.g., 1 for mono, 2 for stereo).
 
 > **sampleRate**: `number`
 
-Defined in: [src/utils/writeWavHeader.ts:10](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/writeWavHeader.ts#L10)
+Defined in: [src/utils/writeWavHeader.ts:10](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/writeWavHeader.ts#L10)
 
 The sample rate of the audio in Hz (e.g., 44100).

--- a/documentation_site/docs/api-reference/API/interfaces/WaveformConfig.md
+++ b/documentation_site/docs/api-reference/API/interfaces/WaveformConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: WaveformConfig
 
-Defined in: [src/ExpoAudioStream.types.ts:413](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L413)
+Defined in: [src/ExpoAudioStream.types.ts:429](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L429)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/ExpoAudioStream.types.ts:413](https://github.com/deeeed/expo-au
 
 > `optional` **color**: `string`
 
-Defined in: [src/ExpoAudioStream.types.ts:415](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L415)
+Defined in: [src/ExpoAudioStream.types.ts:431](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L431)
 
 The color of the waveform (e.g., "#FFFFFF" for white)
 
@@ -24,7 +24,7 @@ The color of the waveform (e.g., "#FFFFFF" for white)
 
 > `optional` **height**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:425](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L425)
+Defined in: [src/ExpoAudioStream.types.ts:441](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L441)
 
 Height of the waveform view in dp (default: 64)
 
@@ -34,7 +34,7 @@ Height of the waveform view in dp (default: 64)
 
 > `optional` **mirror**: `boolean`
 
-Defined in: [src/ExpoAudioStream.types.ts:423](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L423)
+Defined in: [src/ExpoAudioStream.types.ts:439](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L439)
 
 Whether to mirror the waveform (symmetrical display)
 
@@ -44,7 +44,7 @@ Whether to mirror the waveform (symmetrical display)
 
 > `optional` **opacity**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:417](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L417)
+Defined in: [src/ExpoAudioStream.types.ts:433](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L433)
 
 Opacity of the waveform (0.0 - 1.0)
 
@@ -54,7 +54,7 @@ Opacity of the waveform (0.0 - 1.0)
 
 > `optional` **strokeWidth**: `number`
 
-Defined in: [src/ExpoAudioStream.types.ts:419](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L419)
+Defined in: [src/ExpoAudioStream.types.ts:435](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L435)
 
 Width of the waveform line (default: 1.5)
 
@@ -64,6 +64,6 @@ Width of the waveform line (default: 1.5)
 
 > `optional` **style**: `"fill"` \| `"stroke"`
 
-Defined in: [src/ExpoAudioStream.types.ts:421](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L421)
+Defined in: [src/ExpoAudioStream.types.ts:437](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L437)
 
 Drawing style: "stroke" for outline, "fill" for solid

--- a/documentation_site/docs/api-reference/API/interfaces/WebConfig.md
+++ b/documentation_site/docs/api-reference/API/interfaces/WebConfig.md
@@ -1,0 +1,26 @@
+[**@siteed/expo-audio-studio**](../README.md)
+
+***
+
+[@siteed/expo-audio-studio](../README.md) / WebConfig
+
+# Interface: WebConfig
+
+Defined in: [src/ExpoAudioStream.types.ts:211](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L211)
+
+Web platform specific configuration options
+
+## Properties
+
+### storeUncompressedAudio?
+
+> `optional` **storeUncompressedAudio**: `boolean`
+
+Defined in: [src/ExpoAudioStream.types.ts:220](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L220)
+
+Whether to store uncompressed audio data for WAV generation
+
+When true, all PCM chunks are stored in memory to create a WAV file when compression is disabled
+When false, uncompressed audio won't be available, but memory usage will be lower
+
+Default: true (for backward compatibility)

--- a/documentation_site/docs/api-reference/API/type-aliases/BitDepth.md
+++ b/documentation_site/docs/api-reference/API/type-aliases/BitDepth.md
@@ -8,4 +8,4 @@
 
 > **BitDepth**: `8` \| `16` \| `32`
 
-Defined in: [src/ExpoAudioStream.types.ts:61](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L61)
+Defined in: [src/ExpoAudioStream.types.ts:61](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L61)

--- a/documentation_site/docs/api-reference/API/type-aliases/ConsoleLike.md
+++ b/documentation_site/docs/api-reference/API/type-aliases/ConsoleLike.md
@@ -8,7 +8,7 @@
 
 > **ConsoleLike**: `object`
 
-Defined in: [src/ExpoAudioStream.types.ts:64](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L64)
+Defined in: [src/ExpoAudioStream.types.ts:64](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L64)
 
 ## Type declaration
 

--- a/documentation_site/docs/api-reference/API/type-aliases/DeviceDisconnectionBehaviorType.md
+++ b/documentation_site/docs/api-reference/API/type-aliases/DeviceDisconnectionBehaviorType.md
@@ -8,6 +8,6 @@
 
 > **DeviceDisconnectionBehaviorType**: *typeof* [`DeviceDisconnectionBehavior`](../variables/DeviceDisconnectionBehavior.md)\[keyof *typeof* [`DeviceDisconnectionBehavior`](../variables/DeviceDisconnectionBehavior.md)\]
 
-Defined in: [src/ExpoAudioStream.types.ts:278](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L278)
+Defined in: [src/ExpoAudioStream.types.ts:291](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L291)
 
 Type for DeviceDisconnectionBehavior values

--- a/documentation_site/docs/api-reference/API/type-aliases/EncodingType.md
+++ b/documentation_site/docs/api-reference/API/type-aliases/EncodingType.md
@@ -8,4 +8,4 @@
 
 > **EncodingType**: `"pcm_32bit"` \| `"pcm_16bit"` \| `"pcm_8bit"`
 
-Defined in: [src/ExpoAudioStream.types.ts:59](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L59)
+Defined in: [src/ExpoAudioStream.types.ts:59](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L59)

--- a/documentation_site/docs/api-reference/API/type-aliases/PCMFormat.md
+++ b/documentation_site/docs/api-reference/API/type-aliases/PCMFormat.md
@@ -8,4 +8,4 @@
 
 > **PCMFormat**: `` `pcm_${BitDepth}bit` ``
 
-Defined in: [src/ExpoAudioStream.types.ts:62](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L62)
+Defined in: [src/ExpoAudioStream.types.ts:62](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L62)

--- a/documentation_site/docs/api-reference/API/type-aliases/RecordingInterruptionReason.md
+++ b/documentation_site/docs/api-reference/API/type-aliases/RecordingInterruptionReason.md
@@ -8,4 +8,4 @@
 
 > **RecordingInterruptionReason**: `"audioFocusLoss"` \| `"audioFocusGain"` \| `"phoneCall"` \| `"phoneCallEnded"` \| `"recordingStopped"` \| `"deviceDisconnected"` \| `"deviceFallback"` \| `"deviceConnected"` \| `"deviceSwitchFailed"`
 
-Defined in: [src/ExpoAudioStream.types.ts:211](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L211)
+Defined in: [src/ExpoAudioStream.types.ts:224](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L224)

--- a/documentation_site/docs/api-reference/API/type-aliases/SampleRate.md
+++ b/documentation_site/docs/api-reference/API/type-aliases/SampleRate.md
@@ -8,4 +8,4 @@
 
 > **SampleRate**: `16000` \| `44100` \| `48000`
 
-Defined in: [src/ExpoAudioStream.types.ts:60](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L60)
+Defined in: [src/ExpoAudioStream.types.ts:60](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L60)

--- a/documentation_site/docs/api-reference/API/variables/DeviceDisconnectionBehavior.md
+++ b/documentation_site/docs/api-reference/API/variables/DeviceDisconnectionBehavior.md
@@ -8,7 +8,7 @@
 
 > `const` **DeviceDisconnectionBehavior**: `object`
 
-Defined in: [src/ExpoAudioStream.types.ts:270](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L270)
+Defined in: [src/ExpoAudioStream.types.ts:283](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L283)
 
 Defines how recording should behave when a device becomes unavailable
 

--- a/documentation_site/docs/api-reference/API/variables/ExpoAudioStreamModule.md
+++ b/documentation_site/docs/api-reference/API/variables/ExpoAudioStreamModule.md
@@ -8,4 +8,4 @@
 
 > **ExpoAudioStreamModule**: `any`
 
-Defined in: [src/ExpoAudioStreamModule.ts:20](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/ExpoAudioStreamModule.ts#L20)
+Defined in: [src/ExpoAudioStreamModule.ts:20](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/ExpoAudioStreamModule.ts#L20)

--- a/documentation_site/docs/api-reference/API/variables/WAV_HEADER_SIZE.md
+++ b/documentation_site/docs/api-reference/API/variables/WAV_HEADER_SIZE.md
@@ -8,4 +8,4 @@
 
 > `const` **WAV\_HEADER\_SIZE**: `44` = `44`
 
-Defined in: [src/utils/convertPCMToFloat32.ts:6](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/utils/convertPCMToFloat32.ts#L6)
+Defined in: [src/utils/convertPCMToFloat32.ts:6](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/utils/convertPCMToFloat32.ts#L6)

--- a/documentation_site/docs/api-reference/API/variables/audioDeviceManager.md
+++ b/documentation_site/docs/api-reference/API/variables/audioDeviceManager.md
@@ -8,4 +8,4 @@
 
 > `const` **audioDeviceManager**: [`AudioDeviceManager`](../classes/AudioDeviceManager.md)
 
-Defined in: [src/AudioDeviceManager.ts:569](https://github.com/deeeed/expo-audio-stream/blob/bb59302490ef4669af79e1b7d51bc0dcaf10e087/packages/expo-audio-studio/src/AudioDeviceManager.ts#L569)
+Defined in: [src/AudioDeviceManager.ts:569](https://github.com/deeeed/expo-audio-stream/blob/acf23f6c5feaf05159a3376898117bd6525f08bd/packages/expo-audio-studio/src/AudioDeviceManager.ts#L569)

--- a/documentation_site/docs/api-reference/recording-config.md
+++ b/documentation_site/docs/api-reference/recording-config.md
@@ -383,9 +383,17 @@ const handleStopRecording = async () => {
 
 ### Platform Considerations
 
-- **iOS**: Both AAC and Opus are supported
-- **Android**: Both AAC and Opus are supported
-- **Web**: Opus is supported, AAC support depends on browser
+- **iOS**: 
+  - AAC is supported and recommended
+  - Opus format is **not supported** on iOS - if requested, the library will automatically fall back to AAC format and emit a warning
+  - Files are written directly to disk rather than stored in memory
+- **Android**: 
+  - Both AAC and Opus are supported
+  - Files are written directly to disk rather than stored in memory
+- **Web**: 
+  - Opus is supported
+  - AAC support depends on browser
+  - Data is stored in memory during recording unless `storeUncompressedAudio: false` is set
 
 ### Streaming Compressed Audio
 

--- a/packages/expo-audio-studio/CONTRIBUTE.md
+++ b/packages/expo-audio-studio/CONTRIBUTE.md
@@ -27,7 +27,7 @@ For Android development, you can use ADB (Android Debug Bridge) to view and filt
 To see all logs from the library:
 
 ```bash
-adb logcat -v time | grep "ExpoAudioStream"
+adb logcat -v time | grep "ExpoAudioStudio"
 ```
 
 #### Filtering by Component
@@ -36,20 +36,20 @@ To view logs from a specific component:
 
 ```bash
 # View logs from the AudioDeviceManager
-adb logcat -v time | grep "ExpoAudioStream:AudioDeviceManager"
+adb logcat -v time | grep "ExpoAudioStudio:AudioDeviceManager"
 
 # View logs from the AudioRecorderManager
-adb logcat -v time | grep "ExpoAudioStream:AudioRecorderManager"
+adb logcat -v time | grep "ExpoAudioStudio:AudioRecorderManager"
 ```
 
 #### Common Debug Commands
 
 ```bash
 # View only errors from the library
-adb logcat -v time | grep "ExpoAudioStream" | grep " E "
+adb logcat -v time | grep "ExpoAudioStudio" | grep " E "
 
 # Save logs to a file for analysis
-adb logcat -v time | grep "ExpoAudioStream" > expo_audio_logs.txt
+adb logcat -v time | grep "ExpoAudioStudio" > expo_audio_logs.txt
 
 # Clear logcat buffer
 adb logcat -c
@@ -57,15 +57,49 @@ adb logcat -c
 
 #### Useful Log Tags
 
-- `ExpoAudioStream:AudioProcessor` - Audio analysis and processing
-- `ExpoAudioStream:AudioDeviceManager` - Device selection and monitoring
-- `ExpoAudioStream:AudioRecorderManager` - Recording lifecycle
-- `ExpoAudioStream:ExpoAudioStreamModule` - Module initialization and API calls
-- `ExpoAudioStream:AudioTrimmer` - Audio trimming operations
+- `ExpoAudioStudio:AudioProcessor` - Audio analysis and processing
+- `ExpoAudioStudio:AudioDeviceManager` - Device selection and monitoring
+- `ExpoAudioStudio:AudioRecorderManager` - Recording lifecycle
+- `ExpoAudioStudio:ExpoAudioStreamModule` - Module initialization and API calls
+- `ExpoAudioStudio:AudioTrimmer` - Audio trimming operations
 
 ### iOS (Xcode)
 
-> This section will be expanded in a future PR to include information about extracting and filtering logs from iOS using Xcode and the Console app.
+This monorepo includes an `AudioDevPlayground` app for testing. When launched in development mode, you can use these commands to view logs:
+
+#### Simulator
+
+```bash
+# View all logs from the AudioDevPlayground app
+xcrun simctl spawn booted log stream --predicate 'process contains "AudioDevPlayground"'
+
+# View only error logs
+xcrun simctl spawn booted log stream --level error --predicate 'process contains "AudioDevPlayground"'
+
+# View logs from our module in the playground app
+xcrun simctl spawn booted log stream --predicate 'process contains "AudioDevPlayground" && subsystem contains "ExpoAudioStream"'
+```
+
+#### Physical Device
+
+For connected physical iOS devices, use these commands instead:
+
+```bash
+# View all logs from the AudioDevPlayground app on device
+log stream --predicate 'process contains "AudioDevPlayground"'
+
+# View only error logs
+log stream --level error --predicate 'process contains "AudioDevPlayground"'
+
+# View logs from our module in the playground app
+log stream --predicate 'process contains "AudioDevPlayground" && subsystem contains "ExpoAudioStream"'
+```
+
+For a better debugging experience, use the Console app:
+
+1. Open **Console** app on your Mac
+2. Select your device/simulator from the sidebar
+3. Filter with: `process:AudioDevPlayground` or similar
 
 ## Code Style
 

--- a/packages/expo-audio-studio/android/src/main/java/net/siteed/audiostream/LogUtils.kt
+++ b/packages/expo-audio-studio/android/src/main/java/net/siteed/audiostream/LogUtils.kt
@@ -3,12 +3,12 @@ package net.siteed.audiostream
 import android.util.Log
 
 /**
- * Utility class for standardized logging across the ExpoAudioStream library.
+ * Utility class for standardized logging across the ExpoAudioStudio library.
  * Provides consistent logging format and tags for easier filtering in logcat.
  */
 object LogUtils {
-    // Format: [ExpoAudioStream:ClassName]
-    private const val TAG_PREFIX = "ExpoAudioStream"
+    // Format: [ExpoAudioStudio:ClassName]
+    private const val TAG_PREFIX = "ExpoAudioStudio"
     
     /**
      * Logs a debug message with a consistent format.

--- a/packages/expo-audio-studio/ios/AudioDeviceManager.swift
+++ b/packages/expo-audio-studio/ios/AudioDeviceManager.swift
@@ -53,7 +53,7 @@ class AudioDeviceManager {
     
     /// Maps AVAudioSession port types to standardized device types
     func mapDeviceType(_ portType: AVAudioSession.Port) -> String {
-        Logger.debug("Mapping device type for port: \(portType.rawValue)")
+        Logger.debug("AudioDeviceManager", "Mapping device type for port: \(portType.rawValue)")
         switch portType {
         case .builtInMic:
             return deviceTypeBuiltinMic
@@ -79,11 +79,11 @@ class AudioDeviceManager {
         let timeSinceLastPreparation = now - AudioDeviceManager.lastPreparationTime
         
         if AudioDeviceManager.isAudioSessionPrepared && !force && timeSinceLastPreparation < 5.0 {
-            Logger.debug("Audio session already prepared, skipping")
+            Logger.debug("AudioDeviceManager", "Audio session already prepared, skipping")
             return true
         }
         
-        Logger.debug("Preparing audio session for device detection")
+        Logger.debug("AudioDeviceManager", "Preparing audio session for device detection")
         do {
             let session = AVAudioSession.sharedInstance()
             
@@ -101,10 +101,10 @@ class AudioDeviceManager {
             AudioDeviceManager.isAudioSessionPrepared = true
             AudioDeviceManager.lastPreparationTime = now
             
-            Logger.debug("Audio session prepared for device detection")
+            Logger.debug("AudioDeviceManager", "Audio session prepared for device detection")
             return true
         } catch {
-            Logger.debug("Failed to prepare audio session: \(error.localizedDescription)")
+            Logger.debug("AudioDeviceManager", "Failed to prepare audio session: \(error.localizedDescription)")
             return false
         }
     }
@@ -116,7 +116,7 @@ class AudioDeviceManager {
         let timeSinceLastPreparation = now - AudioDeviceManager.lastPreparationTime
         
         if timeSinceLastPreparation < 1.0 {
-            Logger.debug("Skipping force refresh - too soon since last preparation (\(timeSinceLastPreparation) seconds)")
+            Logger.debug("AudioDeviceManager", "Skipping force refresh - too soon since last preparation (\(timeSinceLastPreparation) seconds)")
             return false
         }
         
@@ -125,7 +125,7 @@ class AudioDeviceManager {
     
     /// Gets capabilities for an audio input device
     func getDeviceCapabilities(_ port: AVAudioSessionPortDescription) -> [String: Any] {
-        Logger.debug("Getting capabilities for device: \(port.portName) (ID: \(port.uid))")
+        Logger.debug("AudioDeviceManager", "Getting capabilities for device: \(port.portName) (ID: \(port.uid))")
         let session = AVAudioSession.sharedInstance()
         
         // Test standard sample rates for support
@@ -146,12 +146,12 @@ class AudioDeviceManager {
     
     /// Gets a list of available audio input devices
     func getAvailableInputDevices(promise: Promise) {
-        Logger.debug("Getting available input devices")
+        Logger.debug("AudioDeviceManager", "Getting available input devices")
         
         // Prepare audio session if needed
         let prepared = prepareAudioSession()
         if !prepared {
-            Logger.debug("Warning: Audio session preparation failed, device list may be incomplete")
+            Logger.debug("AudioDeviceManager", "Warning: Audio session preparation failed, device list may be incomplete")
         }
         
         do {
@@ -174,7 +174,7 @@ class AudioDeviceManager {
                 
                 let deviceId = normalizeBluetoothDeviceId(input.uid)
                 
-                Logger.debug("Current route device: \(input.portName) (type: \(deviceType), ID: \(deviceId))")
+                Logger.debug("AudioDeviceManager", "Current route device: \(input.portName) (type: \(deviceType), ID: \(deviceId))")
                 
                 devices.append([
                     "id": deviceId,
@@ -199,7 +199,7 @@ class AudioDeviceManager {
                     
                     // Skip if already in our list
                     if !devices.contains(where: { ($0["id"] as? String) == deviceId }) {
-                        Logger.debug("Available input: \(port.portName) (type: \(deviceType), ID: \(deviceId))")
+                        Logger.debug("AudioDeviceManager", "Available input: \(port.portName) (type: \(deviceType), ID: \(deviceId))")
                         
                         devices.append([
                             "id": deviceId,
@@ -214,22 +214,22 @@ class AudioDeviceManager {
                 }
             }
             
-            Logger.debug("Found \(devices.count) available input devices")
+            Logger.debug("AudioDeviceManager", "Found \(devices.count) available input devices")
             promise.resolve(devices)
         } catch {
-            Logger.debug("Error getting available input devices: \(error.localizedDescription)")
+            Logger.debug("AudioDeviceManager", "Error getting available input devices: \(error.localizedDescription)")
             promise.reject("DEVICE_DETECTION_ERROR", "Failed to get available audio devices: \(error.localizedDescription)")
         }
     }
     
     /// Gets the currently selected audio input device
     func getCurrentInputDevice(promise: Promise) {
-        Logger.debug("Getting current input device")
+        Logger.debug("AudioDeviceManager", "Getting current input device")
         
         // Prepare audio session if needed
         let prepared = prepareAudioSession()
         if !prepared {
-            Logger.debug("Warning: Audio session preparation failed, current device may not be correctly detected")
+            Logger.debug("AudioDeviceManager", "Warning: Audio session preparation failed, current device may not be correctly detected")
         }
         
         do {
@@ -245,7 +245,7 @@ class AudioDeviceManager {
                 let isDefault = session.preferredInput == nil || session.preferredInput?.portType == currentPort.portType
                 let deviceId = normalizeBluetoothDeviceId(currentPort.uid)
                 
-                Logger.debug("Current input device: \(currentPort.portName) (ID: \(deviceId), type: \(deviceType))")
+                Logger.debug("AudioDeviceManager", "Current input device: \(currentPort.portName) (ID: \(deviceId), type: \(deviceType))")
                 
                 let device: [String: Any] = [
                     "id": deviceId,
@@ -266,7 +266,7 @@ class AudioDeviceManager {
                 let deviceType = mapDeviceType(preferredInput.portType)
                 let deviceId = normalizeBluetoothDeviceId(preferredInput.uid)
                 
-                Logger.debug("Current input from preferred: \(preferredInput.portName) (ID: \(deviceId), type: \(deviceType))")
+                Logger.debug("AudioDeviceManager", "Current input from preferred: \(preferredInput.portName) (ID: \(deviceId), type: \(deviceType))")
                 
                 let device: [String: Any] = [
                     "id": deviceId,
@@ -283,10 +283,10 @@ class AudioDeviceManager {
             }
             
             // No input device is currently selected
-            Logger.debug("No current input device found")
+            Logger.debug("AudioDeviceManager", "No current input device found")
             promise.resolve(nil)
         } catch {
-            Logger.debug("Error getting current input device: \(error.localizedDescription)")
+            Logger.debug("AudioDeviceManager", "Error getting current input device: \(error.localizedDescription)")
             promise.reject("DEVICE_DETECTION_ERROR", "Failed to get current audio device: \(error.localizedDescription)")
         }
     }
@@ -294,11 +294,11 @@ class AudioDeviceManager {
     /// Gets the default audio input device (usually built-in mic)
     /// This is an async version useful for fallback logic.
     func getDefaultInputDevice() async -> AudioDevice? {
-        Logger.debug("Getting default input device")
+        Logger.debug("AudioDeviceManager", "Getting default input device")
 
         let prepared = prepareAudioSession()
         if !prepared {
-            Logger.debug("Warning: Audio session preparation failed, default device detection may be inaccurate")
+            Logger.debug("AudioDeviceManager", "Warning: Audio session preparation failed, default device detection may be inaccurate")
         }
 
         let session = AVAudioSession.sharedInstance()
@@ -311,7 +311,7 @@ class AudioDeviceManager {
                 let deviceId = normalizeBluetoothDeviceId(defaultPort.uid)
                 let capabilities = getDeviceCapabilities(defaultPort)
 
-                 Logger.debug("Found default device: \(defaultPort.portName) (ID: \(deviceId), Type: \(deviceType))")
+                 Logger.debug("AudioDeviceManager", "Found default device: \(defaultPort.portName) (ID: \(deviceId), Type: \(deviceType))")
 
                 // Convert capabilities dictionary to Capabilities struct/object if needed
                  let audioCapabilities = AudioDeviceCapabilities(
@@ -330,23 +330,23 @@ class AudioDeviceManager {
                      isAvailable: true // It's available if found here
                  )
             } else {
-                Logger.debug("Could not find built-in mic as default device.")
+                Logger.debug("AudioDeviceManager", "Could not find built-in mic as default device.")
                 return nil
             }
         } catch {
-            Logger.debug("Error getting default input device: \(error)")
+            Logger.debug("AudioDeviceManager", "Error getting default input device: \(error)")
             return nil
         }
     }
     
     /// Selects a specific audio input device for recording
     func selectInputDevice(_ deviceId: String, promise: Promise) {
-        Logger.debug("Attempting to select input device with ID: \(deviceId)")
+        Logger.debug("AudioDeviceManager", "Attempting to select input device with ID: \(deviceId)")
         
         // Prepare audio session - use force: true for device selection to ensure we get the latest devices
         let prepared = prepareAudioSession(force: true)
         if !prepared {
-            Logger.debug("Warning: Audio session preparation failed, device selection may not work correctly")
+            Logger.debug("AudioDeviceManager", "Warning: Audio session preparation failed, device selection may not work correctly")
         }
         
         do {
@@ -359,7 +359,7 @@ class AudioDeviceManager {
             let normalizedRequestedId = normalizeBluetoothDeviceId(deviceId)
             let isBluetoothDevice = deviceId.contains(":")
             
-            Logger.debug("Selecting \(isBluetoothDevice ? "Bluetooth" : "non-Bluetooth") device with normalized ID: \(normalizedRequestedId)")
+            Logger.debug("AudioDeviceManager", "Selecting \(isBluetoothDevice ? "Bluetooth" : "non-Bluetooth") device with normalized ID: \(normalizedRequestedId)")
             
             // Find the device with the specified ID
             let selectedPort: AVAudioSessionPortDescription?
@@ -369,29 +369,29 @@ class AudioDeviceManager {
                 selectedPort = session.availableInputs?.first { port in
                     let portNormalizedId = normalizeBluetoothDeviceId(port.uid)
                     let matches = portNormalizedId == normalizedRequestedId
-                    Logger.debug("Checking device \(port.portName) (ID: \(port.uid), Normalized: \(portNormalizedId)) - Matches: \(matches)")
+                    Logger.debug("AudioDeviceManager", "Checking device \(port.portName) (ID: \(port.uid), Normalized: \(portNormalizedId)) - Matches: \(matches)")
                     return matches
                 }
             } else {
                 // For non-Bluetooth devices, direct match
                 selectedPort = session.availableInputs?.first { port in
                     let matches = port.uid == deviceId
-                    Logger.debug("Checking device \(port.portName) (ID: \(port.uid)) - Matches: \(matches)")
+                    Logger.debug("AudioDeviceManager", "Checking device \(port.portName) (ID: \(port.uid)) - Matches: \(matches)")
                     return matches
                 }
             }
             
             guard let selectedPort = selectedPort else {
-                Logger.debug("Device not found with ID \(deviceId)")
+                Logger.debug("AudioDeviceManager", "Device not found with ID \(deviceId)")
                 
                 // Log all available devices to help debugging
                 if let availableInputs = session.availableInputs {
-                    Logger.debug("Available devices:")
+                    Logger.debug("AudioDeviceManager", "Available devices:")
                     for (index, device) in availableInputs.enumerated() {
-                        Logger.debug("\(index+1). \(device.portName) (ID: \(device.uid), Normalized: \(normalizeBluetoothDeviceId(device.uid)))")
+                        Logger.debug("AudioDeviceManager", "\(index+1). \(device.portName) (ID: \(device.uid), Normalized: \(normalizeBluetoothDeviceId(device.uid)))")
                     }
                 } else {
-                    Logger.debug("No available devices found")
+                    Logger.debug("AudioDeviceManager", "No available devices found")
                 }
                 
                 promise.reject("DEVICE_NOT_FOUND", "The selected audio device is not available")
@@ -399,31 +399,31 @@ class AudioDeviceManager {
             }
             
             // Set the preferred input device
-            Logger.debug("Setting preferred input to: \(selectedPort.portName) (ID: \(selectedPort.uid))")
+            Logger.debug("AudioDeviceManager", "Setting preferred input to: \(selectedPort.portName) (ID: \(selectedPort.uid))")
             try session.setPreferredInput(selectedPort)
             
             // Verify selection
             if let currentInput = session.currentRoute.inputs.first {
                 let succeeded = (currentInput.uid == selectedPort.uid || 
                                 normalizeBluetoothDeviceId(currentInput.uid) == normalizeBluetoothDeviceId(selectedPort.uid))
-                Logger.debug("Device selection \(succeeded ? "succeeded" : "failed") - Current device: \(currentInput.portName) (ID: \(currentInput.uid))")
+                Logger.debug("AudioDeviceManager", "Device selection \(succeeded ? "succeeded" : "failed") - Current device: \(currentInput.portName) (ID: \(currentInput.uid))")
             }
             
-            Logger.debug("Device selected successfully")
+            Logger.debug("AudioDeviceManager", "Device selected successfully")
             promise.resolve(true)
         } catch {
-            Logger.debug("Failed to select device: \(error.localizedDescription)")
+            Logger.debug("AudioDeviceManager", "Failed to select device: \(error.localizedDescription)")
             promise.reject("DEVICE_SELECTION_FAILED", "Failed to select audio device: \(error.localizedDescription)")
         }
     }
     
     /// Selects a specific audio input device asynchronously (useful for internal calls)
     func selectDevice(_ deviceId: String) async -> Bool {
-        Logger.debug("Attempting to select input device with ID: \(deviceId) (async)")
+        Logger.debug("AudioDeviceManager", "Attempting to select input device with ID: \(deviceId) (async)")
 
         let prepared = prepareAudioSession(force: true)
         if !prepared {
-            Logger.debug("Warning: Audio session preparation failed, device selection may not work correctly")
+            Logger.debug("AudioDeviceManager", "Warning: Audio session preparation failed, device selection may not work correctly")
             return false
         }
 
@@ -434,7 +434,7 @@ class AudioDeviceManager {
             let normalizedRequestedId = normalizeBluetoothDeviceId(deviceId)
             let isBluetoothDevice = deviceId.contains(":")
 
-            Logger.debug("Selecting \(isBluetoothDevice ? "Bluetooth" : "non-Bluetooth") device with normalized ID: \(normalizedRequestedId)")
+            Logger.debug("AudioDeviceManager", "Selecting \(isBluetoothDevice ? "Bluetooth" : "non-Bluetooth") device with normalized ID: \(normalizedRequestedId)")
 
             let selectedPort: AVAudioSessionPortDescription?
             if isBluetoothDevice {
@@ -446,11 +446,11 @@ class AudioDeviceManager {
             }
 
             guard let portToSet = selectedPort else {
-                Logger.debug("Device not found with ID \(deviceId) for async selection")
+                Logger.debug("AudioDeviceManager", "Device not found with ID \(deviceId) for async selection")
                 return false
             }
 
-            Logger.debug("Setting preferred input to: \(portToSet.portName) (ID: \(portToSet.uid)) (async)")
+            Logger.debug("AudioDeviceManager", "Setting preferred input to: \(portToSet.portName) (ID: \(portToSet.uid)) (async)")
             try session.setPreferredInput(portToSet)
              // Add a small delay hoping the system applies the change before potential next operations
             try await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
@@ -458,7 +458,7 @@ class AudioDeviceManager {
             // Optional: Verify selection succeeded (might be less reliable immediately after setting)
             if let currentInput = session.currentRoute.inputs.first {
                  let succeeded = (currentInput.uid == portToSet.uid || normalizeBluetoothDeviceId(currentInput.uid) == normalizedRequestedId)
-                 Logger.debug("Async selection verification: \(succeeded ? "succeeded" : "failed")")
+                 Logger.debug("AudioDeviceManager", "Async selection verification: \(succeeded ? "succeeded" : "failed")")
                  return succeeded
              } else {
                  // If no current input after setting, assume failure
@@ -466,19 +466,19 @@ class AudioDeviceManager {
              }
 
         } catch {
-            Logger.debug("Failed to select device asynchronously: \(error.localizedDescription)")
+            Logger.debug("AudioDeviceManager", "Failed to select device asynchronously: \(error.localizedDescription)")
             return false
         }
     }
     
     /// Determines if a device is still available
     func isDeviceAvailable(_ deviceId: String) -> Bool {
-        Logger.debug("Checking availability for device ID: \(deviceId)")
+        Logger.debug("AudioDeviceManager", "Checking availability for device ID: \(deviceId)")
         
         // Prepare audio session if needed
         let prepared = prepareAudioSession()
         if !prepared {
-            Logger.debug("Warning: Audio session preparation failed, device availability check may not be accurate")
+            Logger.debug("AudioDeviceManager", "Warning: Audio session preparation failed, device availability check may not be accurate")
         }
         
         let session = AVAudioSession.sharedInstance()
@@ -491,26 +491,26 @@ class AudioDeviceManager {
             let baseDeviceId = deviceId.split(separator: "-").first ?? Substring(deviceId)
             
             // Log all available inputs for debugging
-            Logger.debug("Available devices to check against:")
+            Logger.debug("AudioDeviceManager", "Available devices to check against:")
             if let availableInputs = session.availableInputs {
                 for (index, device) in availableInputs.enumerated() {
                     let normalizedId = normalizeBluetoothDeviceId(device.uid)
                     let matches = device.uid.starts(with: String(baseDeviceId))
-                    Logger.debug("\(index+1). \(device.portName) (ID: \(device.uid), Normalized: \(normalizedId)) - Matches: \(matches)")
+                    Logger.debug("AudioDeviceManager", "\(index+1). \(device.portName) (ID: \(device.uid), Normalized: \(normalizedId)) - Matches: \(matches)")
                 }
             } else {
-                Logger.debug("No available devices found")
+                Logger.debug("AudioDeviceManager", "No available devices found")
             }
             
             // Also check current route
             for (index, input) in session.currentRoute.inputs.enumerated() {
                 let normalizedId = normalizeBluetoothDeviceId(input.uid)
                 let matches = input.uid.starts(with: String(baseDeviceId))
-                Logger.debug("Current route input \(index+1): \(input.portName) (ID: \(input.uid), Normalized: \(normalizedId)) - Matches: \(matches)")
+                Logger.debug("AudioDeviceManager", "Current route input \(index+1): \(input.portName) (ID: \(input.uid), Normalized: \(normalizedId)) - Matches: \(matches)")
             }
             
             let result = session.availableInputs?.contains { $0.uid.starts(with: String(baseDeviceId)) } ?? false
-            Logger.debug("Bluetooth device \(deviceId) with base ID \(baseDeviceId) available: \(result)")
+            Logger.debug("AudioDeviceManager", "Bluetooth device \(deviceId) with base ID \(baseDeviceId) available: \(result)")
             return result
         } else {
             // Standard device ID check for non-Bluetooth devices
@@ -521,12 +521,12 @@ class AudioDeviceManager {
     /// Resets the selected device to system default (usually built-in mic)
     /// - Parameter completion: Callback with success (Bool) and optional error
     func resetToDefaultDevice(completion: @escaping (Bool, Error?) -> Void) {
-        Logger.debug("Attempting to reset to default input device")
+        Logger.debug("AudioDeviceManager", "Attempting to reset to default input device")
         
         // Prepare audio session if needed
         let prepared = prepareAudioSession()
         if !prepared {
-            Logger.debug("Warning: Audio session preparation failed, device reset may not work correctly")
+            Logger.debug("AudioDeviceManager", "Warning: Audio session preparation failed, device reset may not work correctly")
         }
         
         do {
@@ -534,9 +534,9 @@ class AudioDeviceManager {
             
             // Log current device before reset
             if let currentDevice = session.currentRoute.inputs.first {
-                Logger.debug("Current device before reset: \(currentDevice.portName) (ID: \(currentDevice.uid))")
+                Logger.debug("AudioDeviceManager", "Current device before reset: \(currentDevice.portName) (ID: \(currentDevice.uid))")
             } else {
-                Logger.debug("No current device before reset")
+                Logger.debug("AudioDeviceManager", "No current device before reset")
             }
             
             // Setting preferred input to nil lets the system choose the default
@@ -544,18 +544,18 @@ class AudioDeviceManager {
             
             // Log the device after reset
             if let newDevice = session.currentRoute.inputs.first {
-                Logger.debug("Reset to default device: \(newDevice.portName) (ID: \(newDevice.uid))")
+                Logger.debug("AudioDeviceManager", "Reset to default device: \(newDevice.portName) (ID: \(newDevice.uid))")
                 
                 // Check if it's actually the built-in mic (which is the typical default)
                 let isBuiltIn = newDevice.portType == .builtInMic
-                Logger.debug("Reset device is built-in mic: \(isBuiltIn)")
+                Logger.debug("AudioDeviceManager", "Reset device is built-in mic: \(isBuiltIn)")
             } else {
-                Logger.debug("No device found after reset")
+                Logger.debug("AudioDeviceManager", "No device found after reset")
             }
             
             completion(true, nil)
         } catch {
-            Logger.debug("Failed to reset to default device: \(error.localizedDescription)")
+            Logger.debug("AudioDeviceManager", "Failed to reset to default device: \(error.localizedDescription)")
             completion(false, error)
         }
     }
@@ -565,7 +565,7 @@ class AudioDeviceManager {
         // Ensure we don't add multiple observers
         stopMonitoringDeviceChanges()
 
-        Logger.debug("Starting device change monitoring")
+        Logger.debug("AudioDeviceManager", "Starting device change monitoring")
         routeChangeObserver = NotificationCenter.default.addObserver(
             forName: AVAudioSession.routeChangeNotification,
             object: nil,
@@ -578,7 +578,7 @@ class AudioDeviceManager {
     /// Stops monitoring device changes
     private func stopMonitoringDeviceChanges() {
         if let observer = routeChangeObserver {
-            Logger.debug("Stopping device change monitoring")
+            Logger.debug("AudioDeviceManager", "Stopping device change monitoring")
             NotificationCenter.default.removeObserver(observer)
             routeChangeObserver = nil
         }
@@ -592,17 +592,17 @@ class AudioDeviceManager {
             return
         }
 
-         Logger.debug("Route change detected, reason: \(reason.rawValue)")
+         Logger.debug("AudioDeviceManager", "Route change detected, reason: \(reason.rawValue)")
 
         // Only proceed if a device was potentially removed or the route changed significantly
         guard reason == .oldDeviceUnavailable || reason == .newDeviceAvailable || reason == .override || reason == .routeConfigurationChange else {
-             Logger.debug("Ignoring route change reason: \(reason.rawValue)")
+             Logger.debug("AudioDeviceManager", "Ignoring route change reason: \(reason.rawValue)")
             return
         }
 
         // Get the *previous* route description
         guard let previousRoute = userInfo[AVAudioSessionRouteChangePreviousRouteKey] as? AVAudioSessionRouteDescription else {
-            Logger.debug("No previous route info found for disconnection check.")
+            Logger.debug("AudioDeviceManager", "No previous route info found for disconnection check.")
             return
         }
 
@@ -615,7 +615,7 @@ class AudioDeviceManager {
             let normalizedPreviousId = normalizeBluetoothDeviceId(previousInputPort.uid)
             // Check if the previously connected input is NOT in the set of currently available inputs
             if !currentInputIds.contains(normalizedPreviousId) {
-                 Logger.debug("Detected disconnection of device: \(previousInputPort.portName) (Normalized ID: \(normalizedPreviousId))")
+                 Logger.debug("AudioDeviceManager", "Detected disconnection of device: \(previousInputPort.portName) (Normalized ID: \(normalizedPreviousId))")
                 // Notify the delegate (AudioStreamManager) about the specific disconnected device
                 delegate?.audioDeviceManager(self, didDetectDisconnectionOfDevice: normalizedPreviousId)
                 // Found a disconnected device, can stop checking previous inputs for this event

--- a/packages/expo-audio-studio/ios/AudioProcessor.swift
+++ b/packages/expo-audio-studio/ios/AudioProcessor.swift
@@ -286,7 +286,7 @@ public class AudioProcessor {
         numberOfChannels: Int
     ) -> AudioAnalysisData? {
         guard !data.isEmpty else {
-            Logger.debug("Data is empty, rejecting")
+            Logger.debug("AudioProcessor", "Data is empty, rejecting")
             reject("DATA_EMPTY", "The audio data is empty.")
             return nil
         }
@@ -305,7 +305,7 @@ public class AudioProcessor {
                 return int32Pointer.map { Float($0) / Float(Int32.max) }
             }
         default:
-            Logger.debug("Unsupported bit depth. Rejecting")
+            Logger.debug("AudioProcessor", "Unsupported bit depth. Rejecting")
             reject("UNSUPPORTED_BIT_DEPTH", "Unsupported bit depth: \(bitDepth)")
             return nil
         }
@@ -337,7 +337,7 @@ public class AudioProcessor {
         bitDepth: Int,
         numberOfChannels: Int
     ) -> AudioAnalysisData? {
-        Logger.debug("Processing audio data with sample rate: \(sampleRate), segmentDurationMs: \(segmentDurationMs), bitDepth: \(bitDepth), numberOfChannels: \(numberOfChannels)")
+        Logger.debug("AudioProcessor", "Processing audio data with sample rate: \(sampleRate), segmentDurationMs: \(segmentDurationMs), bitDepth: \(bitDepth), numberOfChannels: \(numberOfChannels)")
         
         let startTime = CACurrentMediaTime()
 
@@ -385,7 +385,7 @@ public class AudioProcessor {
         let endTime = CACurrentMediaTime()
         let processingTimeMs = Float((endTime - startTime) * 1000)
 
-        Logger.debug("Processed \(dataPoints.count) data points in \(processingTimeMs) ms")
+        Logger.debug("AudioProcessor", "Processed \(dataPoints.count) data points in \(processingTimeMs) ms")
 
         return AudioAnalysisData(
             segmentDurationMs: segmentDurationMs,
@@ -511,7 +511,7 @@ public class AudioProcessor {
         featureOptions: [String: Bool]
     ) -> AudioAnalysisData? {
         guard let audioFile = audioFile else {
-            Logger.debug("No audio file loaded")
+            Logger.debug("AudioProcessor", "No audio file loaded")
             return nil
         }
 
@@ -527,7 +527,7 @@ public class AudioProcessor {
         
         // Validate frame range
         guard startFrame >= 0 && endFrame <= audioFile.length && startFrame < endFrame else {
-            Logger.debug("Invalid time range")
+            Logger.debug("AudioProcessor", "Invalid time range")
             return nil
         }
 
@@ -535,7 +535,7 @@ public class AudioProcessor {
         let framesPerBuffer = AVAudioFrameCount(Float(sampleRate) * Float(segmentDurationMs) / 1000.0)
         
         guard let buffer = AVAudioPCMBuffer(pcmFormat: audioFile.processingFormat, frameCapacity: framesPerBuffer) else {
-            Logger.debug("Failed to create buffer")
+            Logger.debug("AudioProcessor", "Failed to create buffer")
             return nil
         }
 
@@ -613,7 +613,7 @@ public class AudioProcessor {
                 dataPoints.append(dataPoint)
                 currentId += 1
             } catch {
-                Logger.debug("Error reading audio data: \(error)")
+                Logger.debug("AudioProcessor", "Error reading audio data: \(error)")
                 return nil
             }
             
@@ -656,20 +656,20 @@ public class AudioProcessor {
         progressCallback: ((Float, Int64, Int64) -> Void)? = nil
     ) -> TrimResult? {
         // Log the input parameters
-        Logger.debug("Starting audio trim operation:")
-        Logger.debug("- Mode: \(mode)")
+        Logger.debug("AudioProcessor", "Starting audio trim operation:")
+        Logger.debug("AudioProcessor", "- Mode: \(mode)")
         if let start = startTimeMs, let end = endTimeMs {
-            Logger.debug("- Time range: \(start)ms to \(end)ms")
+            Logger.debug("AudioProcessor", "- Time range: \(start)ms to \(end)ms")
         }
         if let ranges = ranges {
-            Logger.debug("- Ranges count: \(ranges.count)")
+            Logger.debug("AudioProcessor", "- Ranges count: \(ranges.count)")
         }
         
         // Log output format details
         if let format = outputFormat {
             let formatType = format["format"] as? String ?? "unknown"
             let bitrate = format["bitrate"] as? Int ?? 0
-            Logger.debug("- Output format: \(formatType), bitrate: \(bitrate)")
+            Logger.debug("AudioProcessor", "- Output format: \(formatType), bitrate: \(bitrate)")
         }
         
         guard let audioFile = audioFile else { return nil }
@@ -696,7 +696,7 @@ public class AudioProcessor {
         let formatStr = validFormats.contains(requestedFormat.lowercased()) ? requestedFormat.lowercased() : "aac"
 
         if formatStr != requestedFormat.lowercased() {
-            Logger.debug("Unsupported format '\(requestedFormat)', falling back to 'aac'")
+            Logger.debug("AudioProcessor", "Unsupported format '\(requestedFormat)', falling back to 'aac'")
         }
 
         let targetSampleRate = outputFormat?["sampleRate"] as? Double ?? inputSampleRate
@@ -747,14 +747,14 @@ public class AudioProcessor {
                 }
 
                 // When creating the output file
-                Logger.debug("Creating output file at: \(outputURL.path)")
+                Logger.debug("AudioProcessor", "Creating output file at: \(outputURL.path)")
                 
                 // After processing is complete
-                Logger.debug("Trim operation completed")
-                Logger.debug("- Output file: \(outputURL.path)")
-                Logger.debug("- File exists: \(FileManager.default.fileExists(atPath: outputURL.path))")
-                Logger.debug("- File size: \(try? FileManager.default.attributesOfItem(atPath: outputURL.path)[.size] as? Int64 ?? 0) bytes")
-                Logger.debug("- File extension: \(outputURL.pathExtension)")
+                Logger.debug("AudioProcessor", "Trim operation completed")
+                Logger.debug("AudioProcessor", "- Output file: \(outputURL.path)")
+                Logger.debug("AudioProcessor", "- File exists: \(FileManager.default.fileExists(atPath: outputURL.path))")
+                Logger.debug("AudioProcessor", "- File size: \(try? FileManager.default.attributesOfItem(atPath: outputURL.path)[.size] as? Int64 ?? 0) bytes")
+                Logger.debug("AudioProcessor", "- File extension: \(outputURL.pathExtension)")
                 
                 return createTrimResult(from: outputURL, keepRanges: keepRanges, formatStr: formatStr, sampleRate: Int(inputSampleRate), channels: inputChannels, bitDepth: 16, bitrate: bitrate)
             } else {
@@ -830,14 +830,14 @@ public class AudioProcessor {
                         // Find closest supported sample rate
                         if !supportedSampleRates.contains(sampleRate) {
                             let closestRate = supportedSampleRates.min(by: { abs($0 - sampleRate) < abs($1 - sampleRate) }) ?? 44100.0
-                            Logger.debug("Unsupported sample rate \(sampleRate)Hz for AAC, using closest supported rate: \(closestRate)Hz")
+                            Logger.debug("AudioProcessor", "Unsupported sample rate \(sampleRate)Hz for AAC, using closest supported rate: \(closestRate)Hz")
                             sampleRate = closestRate
                         }
                         
                         // Validate channels (AAC typically supports 1 or 2 channels)
                         var channels = outputFormat?["channels"] as? Int ?? 2
                         if channels > 2 {
-                            Logger.debug("AAC encoding doesn't support \(channels) channels, limiting to 2 channels")
+                            Logger.debug("AudioProcessor", "AAC encoding doesn't support \(channels) channels, limiting to 2 channels")
                             channels = 2
                         } else if channels < 1 {
                             channels = 1
@@ -846,10 +846,10 @@ public class AudioProcessor {
                         // Validate bitrate (AAC typically supports 8000-320000 bps)
                         var bitrate = outputFormat?["bitrate"] as? Int ?? 128000
                         if bitrate < 8000 {
-                            Logger.debug("AAC bitrate too low, setting to minimum 8000 bps")
+                            Logger.debug("AudioProcessor", "AAC bitrate too low, setting to minimum 8000 bps")
                             bitrate = 8000
                         } else if bitrate > 320000 {
-                            Logger.debug("AAC bitrate too high, setting to maximum 320000 bps")
+                            Logger.debug("AudioProcessor", "AAC bitrate too high, setting to maximum 320000 bps")
                             bitrate = 320000
                         }
                         
@@ -863,7 +863,7 @@ public class AudioProcessor {
                         ]
                         fileType = .m4a
                         
-                        Logger.debug("""
+                        Logger.debug("AudioProcessor", """
                             Configuring AAC output:
                             - Container: m4a
                             - Format: AAC
@@ -939,7 +939,7 @@ public class AudioProcessor {
                                 }
                                 
                                 if let error = error {
-                                    Logger.debug("Conversion error: \(error)")
+                                    Logger.debug("AudioProcessor", "Conversion error: \(error)")
                                     continue
                                 }
                                 
@@ -951,7 +951,7 @@ public class AudioProcessor {
                                     }
                                     
                                     if !writerInput.append(sampleBuffer) {
-                                        Logger.debug("Failed to append sample buffer: \(assetWriter.error?.localizedDescription ?? "Unknown error")")
+                                        Logger.debug("AudioProcessor", "Failed to append sample buffer: \(assetWriter.error?.localizedDescription ?? "Unknown error")")
                                     }
                                 }
                                 
@@ -961,11 +961,11 @@ public class AudioProcessor {
                                 progressCallback?(progress, 0, totalFrames * Int64(inputFormat.streamDescription.pointee.mBytesPerFrame))
                                 
                                 if framesProcessed % 10000 == 0 { // Log every 10000 frames to avoid excessive logging
-                                    Logger.debug("Processed \(framesProcessed)/\(totalFramesToProcess) frames")
+                                    Logger.debug("AudioProcessor", "Processed \(framesProcessed)/\(totalFramesToProcess) frames")
                                 }
                                 
                             } catch {
-                                Logger.debug("Error reading audio: \(error)")
+                                Logger.debug("AudioProcessor", "Error reading audio: \(error)")
                                 break
                             }
                         }
@@ -976,15 +976,15 @@ public class AudioProcessor {
                     let finishSemaphore = DispatchSemaphore(value: 0)
                     assetWriter.finishWriting { 
                         if let error = assetWriter.error {
-                            Logger.debug("Error finishing writing: \(error)")
+                            Logger.debug("AudioProcessor", "Error finishing writing: \(error)")
                         } else {
-                            Logger.debug("Writing finished successfully")
+                            Logger.debug("AudioProcessor", "Writing finished successfully")
                             
                             // Verify the output file
                             let fileExists = FileManager.default.fileExists(atPath: tempOutputURL.path)
                             let fileSize = (try? FileManager.default.attributesOfItem(atPath: tempOutputURL.path)[.size] as? Int64) ?? 0
                             
-                            Logger.debug("""
+                            Logger.debug("AudioProcessor", """
                                 Output file verification:
                                 - Path: \(tempOutputURL.path)
                                 - Exists: \(fileExists)

--- a/packages/expo-audio-studio/ios/ExpoAudioStreamModule.swift
+++ b/packages/expo-audio-studio/ios/ExpoAudioStreamModule.swift
@@ -166,8 +166,25 @@ public class ExpoAudioStreamModule: Module, AudioStreamManagerDelegate {
                     return
                 }
                 
-                // Create settings with validation
-                let settingsResult = RecordingSettings.fromDictionary(options)
+                // Check if compression is enabled and format is Opus
+                var modifiedOptions = options
+                if let compression = options["compression"] as? [String: Any],
+                   let enabled = compression["enabled"] as? Bool, enabled,
+                   let format = compression["format"] as? String,
+                   format.lowercased() == "opus" {
+                    
+                    // Create a mutable copy of the compression dictionary
+                    var modifiedCompression = compression
+                    
+                    // Change format to AAC and log warning
+                    modifiedCompression["format"] = "aac"
+                    modifiedOptions["compression"] = modifiedCompression
+                    
+                    Logger.warn("[ExpoAudioStreamModule] startRecording: Opus format is not supported on iOS. Falling back to AAC format.")
+                }
+                
+                // Create settings with validation using the potentially modified options
+                let settingsResult = RecordingSettings.fromDictionary(modifiedOptions)
                 
                 switch settingsResult {
                 case .success(let settings):

--- a/packages/expo-audio-studio/ios/Logger.swift
+++ b/packages/expo-audio-studio/ios/Logger.swift
@@ -1,19 +1,39 @@
 class Logger {
-    static func debug(_ message: @autoclosure () -> String) {
+    // Similar to Android's TAG_PREFIX for consistent cross-platform logging
+    private static let TAG_PREFIX = "ExpoAudioStudio"
+    
+    static func debug(_ className: String, _ message: @autoclosure () -> String) {
         #if DEBUG
-        print("[DEBUG] \(message())")
+        print("[\(TAG_PREFIX):\(className)] [DEBUG] \(message())")
         #endif
     }
 
+    static func info(_ className: String, _ message: @autoclosure () -> String) {
+        print("[\(TAG_PREFIX):\(className)] [INFO] \(message())")
+    }
+
+    static func warn(_ className: String, _ message: @autoclosure () -> String) {
+        print("[\(TAG_PREFIX):\(className)] [WARN] ⚠️ \(message())")
+    }
+
+    static func error(_ className: String, _ message: @autoclosure () -> String) {
+        print("[\(TAG_PREFIX):\(className)] [ERROR] 🛑 \(message())")
+    }
+    
+    // For backward compatibility with code that doesn't specify a class name
+    static func debug(_ message: @autoclosure () -> String) {
+        debug("General", message())
+    }
+    
     static func info(_ message: @autoclosure () -> String) {
-        print("[INFO] \(message())")
+        info("General", message())
     }
-
+    
     static func warn(_ message: @autoclosure () -> String) {
-        print("[WARN] ⚠️ \(message())")
+        warn("General", message())
     }
-
+    
     static func error(_ message: @autoclosure () -> String) {
-        print("[ERROR] 🛑 \(message())")
+        error("General", message())
     }
 }

--- a/packages/expo-audio-studio/src/ExpoAudioStream.types.ts
+++ b/packages/expo-audio-studio/src/ExpoAudioStream.types.ts
@@ -344,7 +344,11 @@ export interface RecordingConfig {
     compression?: {
         /** Enable audio compression */
         enabled: boolean
-        /** Format for compression (aac or opus) */
+        /** 
+         * Format for compression
+         * - 'aac': Advanced Audio Coding - supported on all platforms
+         * - 'opus': Opus encoding - supported on Android and Web; on iOS will automatically fall back to AAC
+         */
         format: 'aac' | 'opus'
         /** Bitrate for compression in bits per second */
         bitrate?: number

--- a/packages/expo-audio-studio/src/useAudioRecorder.tsx
+++ b/packages/expo-audio-studio/src/useAudioRecorder.tsx
@@ -212,8 +212,7 @@ export function useAudioRecorder({
             const maxDuration = visualizationDuration
 
             logger?.debug(
-                `[handleAudioAnalysis] Received audio analysis: maxDuration=${maxDuration} analysis.dataPoints=${analysis.dataPoints.length} analysisData.dataPoints=${savedAnalysisData.dataPoints.length}`,
-                analysis
+                `[handleAudioAnalysis] Received audio analysis: maxDuration=${maxDuration} analysis.dataPoints=${analysis.dataPoints.length} analysisData.dataPoints=${savedAnalysisData.dataPoints.length}`
             )
 
             // Combine data points


### PR DESCRIPTION
# Description

This pull request addresses a critical issue on iOS where the app crashes with a "Format mismatch" error (`com.apple.coreaudio.avfaudio: input HW format is invalid`) during recording preparation, as reported in issue #218. The root cause was identified as a mismatch between the audio tap format and the hardware's actual input format, particularly when switching devices or resuming recording. Additionally, this PR improves logging consistency across platforms and enhances the iOS playground app for better debugging and validation.

## Purpose and Impact
- **Fix iOS Crash (#218):** Resolves the format mismatch crash by ensuring the audio tap is installed using the hardware's actual input format (`inputNode.inputFormat`) rather than relying on potentially inconsistent session or node output formats. This fix ensures stable recording across device changes (e.g., Bluetooth headsets) and resume operations.
- **Improved Logging:** Standardizes logging tags across platforms by adopting the `ExpoAudioStudio` prefix, making it easier to filter and debug logs on both Android and iOS. Enhanced log messages provide better context for debugging recording, device management, and audio processing.
- **Playground Enhancement for iOS:** Adds the `AudioDevPlayground` app for testing and includes detailed logging instructions in the `CONTRIBUTE.md` file, enabling developers to validate recording behavior on iOS simulators and physical devices.

## Key Implementation Details
- **Hardware Format Detection (iOS):**
  - Introduced a new `installTapWithHardwareFormat` method in `AudioStreamManager.swift` to query `inputNode.inputFormat(forBus: 0)` just before installing the audio tap, ensuring compatibility with the hardware's actual format.
  - Updated recording preparation, resume, and device fallback logic to reinstall the tap with the correct hardware format, preventing format mismatch crashes.
  - Added aggressive recovery mechanisms in the fallback handler to ensure data continuity after device disconnection, including forced emissions and engine restarts.
- **Compression Format Handling:**
  - Modified `ExpoAudioStreamModule.swift` to automatically fall back to AAC on iOS when Opus is requested, as Opus is not supported on iOS. This fallback is logged as a warning to inform developers.
  - Updated `RecordingSettings.tsx` to enforce AAC as the only compression format on iOS, with clear user feedback in the UI.
- **Logging Improvements:**
  - Standardized logging tags across platforms using the `ExpoAudioStudio` prefix (e.g., `ExpoAudioStudio:AudioDeviceManager`).
  - Enhanced iOS logging in `Logger.swift` to include class names for better context.
  - Updated `CONTRIBUTE.md` with detailed instructions for filtering logs on both Android and iOS, including commands for viewing logs from the `AudioDevPlayground` app.
- **Documentation Updates:**
  - Updated `recording-config.md` to clarify platform-specific compression support (e.g., Opus not supported on iOS, automatic fallback to AAC).
  - Added detailed root cause analysis and solution steps in `ISSUE_IOS.md` for future reference.
- **Playground Enhancements:**
  - Added the `AudioDevPlayground` app for iOS testing, with instructions in `CONTRIBUTE.md` for viewing logs on simulators and physical devices.
  - Improved recording preparation logic in `record.tsx` to track configuration changes and re-prepare when necessary, reducing the likelihood of crashes due to stale configurations.

## Breaking Changes
- **Compression Format on iOS:** Opus compression is no longer supported on iOS and will automatically fall back to AAC. This may affect apps that explicitly rely on Opus for iOS recordings.
  - **Migration Step:** Update any recording configurations that specify Opus on iOS to use AAC instead. The library will handle the fallback automatically, but developers should ensure their app logic accounts for AAC output on iOS.
