### PR TITLE
feat: Update AudioPlayground branding and enhance app distribution

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,13 +1,13 @@
 ---
 name: Bug report
-about: Create a bug report to help improve expo-audio-stream
+about: Create a bug report to help improve expo-audio-studio
 title: '[BUG] '
 labels: bug
 assignees: ''
 ---
 
 ## Environment
-- expo-audio-stream version: <!-- e.g., 1.2.0 -->
+- expo-audio-studio version: <!-- e.g., 1.2.0 -->
 - Expo SDK version: <!-- e.g., 49.0.0 -->
 - React Native version: <!-- e.g., 0.72.3 -->
 - Platform & OS version: <!-- e.g., iOS 16.5, Android 13, Web Chrome 115 -->
@@ -16,19 +16,33 @@ assignees: ''
 ## Description
 <!-- A clear and concise description of the issue -->
 
-**Playground Reproduction**
-<!-- Have you tried reproducing this in our Playground app? -->
-<!-- https://deeeed.github.io/expo-audio-stream/playground -->
-- [ ] Yes, it can be reproduced in the Playground
+## Cross-Platform Validation
+<!-- It helps tremendously if you can try to reproduce the issue on the official AudioPlayground app -->
+
+### AudioPlayground Apps
+- Web: https://deeeed.github.io/expo-audio-stream/playground
+- iOS: https://apps.apple.com/app/audio-playground/id6739774966
+- Android: https://play.google.com/store/apps/details?id=net.siteed.audioplayground
+
+**Important:** The AudioPlayground app exposes **all features** of the expo-audio-studio library with full customization:
+- In the **Record** tab, toggle "Show Advanced Settings" to access all recording parameters
+- In the **Trim** tab, you can test all audio processing capabilities
+- All visualization and transcription features are available to test
+- Try different audio devices, sample rates, and compression settings
+
+Can this issue be reproduced in the AudioPlayground app?
+- [ ] Yes, on all platforms (Web, iOS, Android)
+- [ ] Yes, but only on specific platforms (please specify): <!-- e.g., iOS only, Android and Web -->
 - [ ] No, it only happens in my app
 
-If yes, please provide the steps in the Playground:
+Reproduction steps in the AudioPlayground app (including any settings you modified):
+1. 
+2. 
+3. 
 
-- 1. 
-- 2. 
-- 3. 
-
-
+Is the behavior consistent across platforms?
+- [ ] Yes, the issue occurs the same way on all platforms I tested
+- [ ] No, the behavior differs between platforms (please describe the differences)
 
 ## Configuration
 
@@ -39,7 +53,6 @@ const config: RecordingConfig = {
   // ... other options
 };
 ```
-
 
 ## Logs
 <!-- 
@@ -57,18 +70,12 @@ Then paste the relevant logs here:
 ```log
 ```
 
-
 ## Media
 <!-- 
 Please provide any relevant media that demonstrates the issue:
 - Screen recording showing the problem
 - Audio sample that demonstrates the issue
 - Screenshots of any error messages
-
-You can record your screen using:
-- iOS: Built-in screen recording (Control Center)
-- Android: Built-in screen recording or ADB
-- Web: Browser dev tools or screen recording software
 -->
 
 ## Expected Behavior
@@ -80,12 +87,16 @@ You can record your screen using:
 ## Additional Context
 <!-- Add any other context about the problem here -->
 
+## Thank You
+Your feedback helps improve this library. Thank you for taking the time to report this issue and provide these details!
+
 ## Checklist
 Before submitting, please check that you have:
-- [ ] Updated to the latest version of expo-audio-stream
+- [ ] Updated to the latest version of expo-audio-studio
 - [ ] Checked the [documentation](https://deeeed.github.io/expo-audio-stream/docs/)
 - [ ] Included complete and relevant logs
-- [ ] Tested in the [Playground app](https://deeeed.github.io/expo-audio-stream/playground) if possible
+- [ ] Tested in the official AudioPlayground app on at least one platform
+- [ ] Compared behavior across multiple platforms if possible
 - [ ] Included a minimal reproduction code example
 - [ ] Checked for existing similar issues
 - [ ] Verified microphone permissions are properly set up

--- a/README.md
+++ b/README.md
@@ -28,7 +28,18 @@ Key features:
 - Speech recognition and audio analysis examples
 - Available on iOS and Android app stores
 
-Try the web version at [https://deeeed.github.io/expo-audio-stream/playground/](https://deeeed.github.io/expo-audio-stream/playground/)
+<div align="center">
+  <p>Try it now:</p>
+  <div style="display: flex; justify-content: center; gap: 20px; margin: 10px 0;">
+    <a href="https://apps.apple.com/app/audio-playground/id6739774966">
+      <img src="https://developer.apple.com/app-store/marketing/guidelines/images/badge-download-on-the-app-store.svg" alt="Download on the App Store" height="40" />
+    </a>
+    <a href="https://play.google.com/store/apps/details?id=net.siteed.audioplayground">
+      <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="40" />
+    </a>
+  </div>
+  <p>Or try the web version at <a href="https://deeeed.github.io/expo-audio-stream/playground/">https://deeeed.github.io/expo-audio-stream/playground/</a></p>
+</div>
 
 ### Sherpa-ONNX Demo
 

--- a/apps/playground/CHANGELOG.md
+++ b/apps/playground/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 
+## [0.12.3] - 2025-05-02
+
+### Changed
+- add Prettier, update linting, and introduce cleanup scripts (#222)
+
 ## [0.12.2] - 2025-05-02
 
 ### Changed
@@ -20,6 +25,8 @@ All notable changes to this project will be documented in this file.
 - Web export capability
 
 
-[unreleased]: https://github.com/deeeed/expo-audio-stream/compare/audio-playground@0.12.2...HEAD
+
+[unreleased]: https://github.com/deeeed/expo-audio-stream/compare/audio-playground@0.12.3...HEAD
+[0.12.3]: https://github.com/deeeed/expo-audio-stream/compare/audio-playground@0.12.2...audio-playground@0.12.3
 [0.12.2]: https://github.com/deeeed/expo-audio-stream/compare/audio-playground@0.12.1...audio-playground@0.12.2
 [0.12.1]: https://github.com/deeeed/expo-audio-stream/releases/tag/audio-playground@0.12.1

--- a/apps/playground/PUBLISH_STORE.md
+++ b/apps/playground/PUBLISH_STORE.md
@@ -2,6 +2,18 @@
 
 This document outlines my release and deployment process for AudioPlayground. It covers versioning, building, and submitting to app stores.
 
+## Current App Availability
+
+AudioPlayground is publicly available on the following platforms:
+
+| Platform | URL |
+|----------|-----|
+| App Store (iOS) | [https://apps.apple.com/app/audio-playground/id6739774966](https://apps.apple.com/app/audio-playground/id6739774966) |
+| Google Play (Android) | [https://play.google.com/store/apps/details?id=net.siteed.audioplayground](https://play.google.com/store/apps/details?id=net.siteed.audioplayground) |
+| Web | [https://deeeed.github.io/expo-audio-stream/playground/](https://deeeed.github.io/expo-audio-stream/playground/) |
+
+When publishing updates, these are the destinations where the app will be updated.
+
 ## System Requirements
 
 Before starting development or deployment, make sure your system has all the necessary dependencies installed:
@@ -105,7 +117,7 @@ eas device:create
 yarn build:ios:production --auto-submit
 
 # Submit latest build to App Store
-eas submit --platform ios --latest
+npx eas submit --platform ios --latest
 ```
 
 ## Over-the-Air Updates
@@ -118,7 +130,7 @@ yarn clean
 yarn install
 
 # Push update
-eas update --message "Description of the changes"
+npx eas update --message "Description of the changes"
 ```
 
 > ⚠️ **Important**: OTA updates only work for builds using the same `runtimeVersion`

--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -2,7 +2,18 @@
 
 A demo application showcasing real-time audio processing and visualization capabilities using **@siteed/expo-audio-studio**. 
 
-[![Web Demo](https://img.shields.io/badge/Demo-Web-blue)](https://deeeed.github.io/expo-audio-stream/)
+<div align="center">
+  <div style="display: flex; justify-content: center; gap: 20px; margin: 10px 0;">
+    <a href="https://apps.apple.com/app/audio-playground/id6739774966">
+      <img src="https://developer.apple.com/app-store/marketing/guidelines/images/badge-download-on-the-app-store.svg" alt="Download on the App Store" height="40" />
+    </a>
+    <a href="https://play.google.com/store/apps/details?id=net.siteed.audioplayground">
+      <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="40" />
+    </a>
+  </div>
+  
+  [![Web Demo](https://img.shields.io/badge/Demo-Web-blue)](https://deeeed.github.io/expo-audio-stream/)
+</div>
 
 ## Features
 

--- a/apps/playground/app.config.ts
+++ b/apps/playground/app.config.ts
@@ -120,7 +120,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     updates: {
         url: 'https://u.expo.dev/' + validatedEnv.EAS_PROJECT_ID,
     },
-    runtimeVersion: '0.12.2',
+    runtimeVersion: '0.12.3',
     owner: 'deeeed',
     plugins: [
         [

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -1,6 +1,6 @@
 {
     "name": "audio-playground",
-    "version": "0.12.2",
+    "version": "0.12.3",
     "main": "src/index",
     "scripts": {
         "eas-build-pre-install": "corepack enable && cd ../.. && yarn install && echo 'Building packages...' && cd packages/expo-audio-studio && yarn build && yarn build:plugin && echo 'Built expo-audio-studio' && cd ../playgroundapi && yarn build && echo 'Built playgroundapi' && cd ../react-native-essentia && yarn prepare || echo 'Warning: react-native-essentia build failed but continuing'",

--- a/apps/playground/src/app/(tabs)/more.tsx
+++ b/apps/playground/src/app/(tabs)/more.tsx
@@ -256,6 +256,19 @@ export const MoreScreen = () => {
                     router.navigate('/logs')
                 }}
             />
+            {isWeb && (
+                <ListItem
+                    contentContainerStyle={{
+                        ...styles.listItemContainer,
+                        backgroundColor: theme.colors.primaryContainer,
+                    }}
+                    label="Download Apps"
+                    subLabel="Get AudioPlayground for iOS and Android"
+                    onPress={() => {
+                        router.navigate('/download')
+                    }}
+                />
+            )}
             <ListItem
                 contentContainerStyle={styles.listItemContainer}
                 label="Permissions"

--- a/apps/playground/src/app/_layout.tsx
+++ b/apps/playground/src/app/_layout.tsx
@@ -12,6 +12,7 @@ import { getLogger } from '@siteed/react-native-logger'
 import { ApplicationContextProvider } from '../context/ApplicationProvider'
 import { AudioFilesProvider } from '../context/AudioFilesProvider'
 import { TranscriptionProvider } from '../context/TranscriptionProvider'
+import { WebAppBanner } from '../components/WebAppBanner'
 import { useAppUpdates } from '../hooks/useAppUpdates'
 import { isWeb } from '../utils/utils'
 const logger = getLogger('RootLayout')
@@ -53,6 +54,9 @@ export default function RootLayout() {
                                 fonts: DefaultTheme.fonts,
                             }}
                         >
+                            {/* WebAppBanner appears above all content on web platform */}
+                            <WebAppBanner />
+                            
                             <Stack
                                 screenOptions={{
                                     headerBackButtonMenuEnabled: false,

--- a/apps/playground/src/app/decibel.tsx
+++ b/apps/playground/src/app/decibel.tsx
@@ -12,6 +12,7 @@ import { DecibelGauge } from '@siteed/expo-audio-ui'
 
 import { DecibelGaugeSettings } from '../component/DecibelGaugeSettings'
 import { baseLogger } from '../config'
+import { useScreenHeader } from '../hooks/useScreenHeader'
 
 import type { GaugeSettings } from '../component/DecibelGaugeSettings'
 
@@ -70,6 +71,12 @@ export default function DecibelScreen() {
     const theme = useTheme()
     const { bottom, top } = useSafeAreaInsets()
     const styles = useMemo(() => getStyles({ theme, insets: { bottom, top } }), [theme, bottom, top])
+    useScreenHeader({
+        title: 'Decibel Meter',
+        backBehavior: {
+            fallbackUrl: '/more',
+        },
+    })
     
     const font = useFont(require('@assets/Roboto/Roboto-Regular.ttf'), 30)
 

--- a/apps/playground/src/app/download.tsx
+++ b/apps/playground/src/app/download.tsx
@@ -1,0 +1,199 @@
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { Button, useTheme } from "@siteed/design-system";
+import { Link } from "expo-router";
+import React from "react";
+import { Linking, Platform, ScrollView, StyleSheet, View } from "react-native";
+import { Text } from "react-native-paper";
+
+// Use generic App Store URL without country code and Google Play URL without language parameter
+const APP_STORE_URL = "https://apps.apple.com/app/audio-playground/id6739774966";
+const PLAY_STORE_URL = "https://play.google.com/store/apps/details?id=net.siteed.audioplayground";
+
+export default function DownloadPage() {
+  const theme = useTheme();
+
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+    content: {
+      padding: 16,
+      alignItems: "center",
+    },
+    title: {
+      ...theme.fonts.headlineMedium,
+      color: theme.colors.onBackground,
+      marginBottom: 16,
+      textAlign: "center",
+    },
+    subtitle: {
+      ...theme.fonts.titleMedium,
+      color: theme.colors.onBackground,
+      marginBottom: 24,
+      textAlign: "center",
+    },
+    storeButtonsContainer: {
+      flexDirection: "row",
+      justifyContent: "center",
+      flexWrap: "wrap",
+      gap: 16,
+      marginBottom: 32,
+    },
+    featureContainer: {
+      width: "100%",
+      maxWidth: 600,
+      marginBottom: 24,
+    },
+    featureTitle: {
+      ...theme.fonts.titleMedium,
+      color: theme.colors.onBackground,
+      marginBottom: 16,
+      textAlign: "center",
+    },
+    featureRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      marginBottom: 12,
+    },
+    featureIcon: {
+      marginRight: 16,
+    },
+    featureText: {
+      ...theme.fonts.bodyMedium,
+      color: theme.colors.onBackground,
+      flex: 1,
+    },
+    webButtonContainer: {
+      marginTop: 24,
+      alignItems: "center",
+    },
+    webButtonText: {
+      ...theme.fonts.bodySmall,
+      color: theme.colors.primary,
+    },
+    divider: {
+      height: 1,
+      backgroundColor: theme.colors.outlineVariant,
+      width: "100%",
+      marginVertical: 24,
+    },
+    paragraph: {
+      ...theme.fonts.bodyMedium,
+      color: theme.colors.onBackground,
+      marginBottom: 16,
+      textAlign: "center",
+      maxWidth: 600,
+    },
+  });
+
+  const openAppStore = () => {
+    Linking.openURL(APP_STORE_URL);
+  };
+
+  const openPlayStore = () => {
+    Linking.openURL(PLAY_STORE_URL);
+  };
+
+  const openGitHub = () => {
+    Linking.openURL("https://github.com/deeeed/expo-audio-stream");
+  };
+
+  return (
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={styles.title}>AudioPlayground</Text>
+        <Text style={styles.subtitle}>
+          Cross-Platform Demo for @siteed/expo-audio-studio
+        </Text>
+
+        <Text style={styles.paragraph}>
+          AudioPlayground demonstrates the capabilities of the expo-audio-studio library across all platforms. 
+          Try it on multiple devices to experience the consistent audio processing capabilities.
+        </Text>
+
+        <View style={styles.storeButtonsContainer}>
+          <Button
+            mode="contained"
+            icon="apple"
+            onPress={openAppStore}
+            style={{ marginRight: 8 }}
+          >
+            App Store
+          </Button>
+          <Button
+            mode="contained"
+            icon="google-play"
+            onPress={openPlayStore}
+          >
+            Google Play
+          </Button>
+        </View>
+
+        <View style={styles.divider} />
+
+        <View style={styles.featureContainer}>
+          <Text style={styles.featureTitle}>Help Improve AudioPlayground</Text>
+          
+          <Text style={styles.paragraph}>
+            By testing across different platforms, you help ensure consistent functionality and identify platform-specific issues.
+            Your feedback is incredibly valuable for the continued improvement of this library!
+          </Text>
+          
+          <View style={styles.featureRow}>
+            <MaterialCommunityIcons
+              name="bug-check"
+              size={24}
+              color={theme.colors.primary}
+              style={styles.featureIcon}
+            />
+            <Text style={styles.featureText}>
+              Try the same features on web, iOS, and Android to verify cross-platform compatibility
+            </Text>
+          </View>
+          
+          <View style={styles.featureRow}>
+            <MaterialCommunityIcons
+              name="github"
+              size={24}
+              color={theme.colors.primary}
+              style={styles.featureIcon}
+            />
+            <Text style={styles.featureText}>
+              Report any issues on GitHub to help improve the library
+            </Text>
+          </View>
+          
+          <View style={styles.featureRow}>
+            <MaterialCommunityIcons
+              name="star"
+              size={24}
+              color={theme.colors.primary}
+              style={styles.featureIcon}
+            />
+            <Text style={styles.featureText}>
+              If you find this useful, please leave a rating on the app stores or star the GitHub repo
+            </Text>
+          </View>
+        </View>
+
+        <Button 
+          mode="outlined" 
+          icon="github"
+          onPress={openGitHub}
+          style={{ marginBottom: 16 }}
+        >
+          View on GitHub
+        </Button>
+
+        {Platform.OS === "web" && (
+          <View style={styles.webButtonContainer}>
+            <Link href="/" asChild>
+              <Button mode="outlined">Back to Web Version</Button>
+            </Link>
+          </View>
+        )}
+      </ScrollView>
+    </View>
+  );
+} 

--- a/apps/playground/src/app/permissions.tsx
+++ b/apps/playground/src/app/permissions.tsx
@@ -10,6 +10,7 @@ import { ScreenWrapper, useTheme } from '@siteed/design-system'
 import { ExpoAudioStreamModule } from '@siteed/expo-audio-studio'
 
 import { baseLogger } from '../config'
+import { useScreenHeader } from '../hooks/useScreenHeader'
 
 interface PermissionStatus {
     status: string
@@ -108,6 +109,12 @@ const getStyles = ({ theme }: { theme: AppTheme }) => {
 export const PermissionsPage = () => {
     const theme = useTheme()
     const styles = getStyles({ theme })
+    
+    useScreenHeader({
+      title: 'Audio Permissions',
+      backBehavior: { fallbackUrl: '/more' },
+    })
+
     const [permissions, setPermissions] = useState<PermissionStatus | null>(
         null
     )

--- a/apps/playground/src/app/preview.tsx
+++ b/apps/playground/src/app/preview.tsx
@@ -15,6 +15,7 @@ import { AudioTimeRangeSelector, AudioVisualizer } from '@siteed/expo-audio-ui'
 import { baseLogger } from '../config'
 import { useSampleAudio } from '../hooks/useSampleAudio'
 import { isWeb } from '../utils/utils'
+import { useScreenHeader } from '../hooks/useScreenHeader'
 
 const SAMPLE_AUDIO = {
     web: '/audio_samples/jfk.mp3',
@@ -80,8 +81,6 @@ export default function PreviewScreen() {
     const [selectedQuickRange, setSelectedQuickRange] = useState<string | undefined>('First 10s')
 
     const { show } = useToast()
-    const font = useFont(require('@assets/Roboto/Roboto-Regular.ttf'), 10)
-    
     const { isLoading: isSampleLoading, loadSampleAudio } = useSampleAudio({
         onError: (error) => {
             logger.error('Error loading sample audio file:', error)
@@ -93,6 +92,15 @@ export default function PreviewScreen() {
         },
     })
 
+    useScreenHeader({
+        title: 'Audio Preview',
+        backBehavior: {
+            fallbackUrl: '/more',
+        },
+    })
+
+    const font = useFont(require('@assets/Roboto/Roboto-Regular.ttf'), 10)
+    
     const generatePreview = useCallback(async (fileUri: string) => {
         try {
             setIsProcessing(true)

--- a/apps/playground/src/app/trim.tsx
+++ b/apps/playground/src/app/trim.tsx
@@ -15,6 +15,7 @@ import { AudioTimeRangeSelector } from '@siteed/expo-audio-ui'
 import TrimVisualization from '../components/TrimVisualization'
 import { baseLogger } from '../config'
 import { useSampleAudio } from '../hooks/useSampleAudio'
+import { useScreenHeader } from '../hooks/useScreenHeader'
 
 import type { AVPlaybackStatus } from 'expo-av'
 
@@ -74,6 +75,13 @@ export default function TrimScreen() {
     const styles = useMemo(() => getStyles({ theme, insets: { bottom, top } }), [theme, bottom, top])
     const colors = theme.colors
     const { show } = useToast()
+
+    useScreenHeader({
+        title: 'Audio Trimming',
+        backBehavior: {
+            fallbackUrl: '/more',
+        },
+    })
 
     // Audio file state
     const [currentFile, setCurrentFile] = useState<AudioFile | null>(null)

--- a/apps/playground/src/components/WebAppBanner.tsx
+++ b/apps/playground/src/components/WebAppBanner.tsx
@@ -1,0 +1,114 @@
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { useTheme } from "@siteed/design-system";
+import { useRouter } from "expo-router";
+import React, { useMemo, useCallback, useState, useEffect } from "react";
+import { Platform, Pressable, StyleSheet, View } from "react-native";
+import { Text } from "react-native-paper";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+// Key for storing banner dismiss state
+const WEB_APP_BANNER_DISMISSED_KEY = "@AudioPlayground:webAppBannerDismissed";
+
+export const WebAppBanner = () => {
+  const theme = useTheme();
+  const router = useRouter();
+  const [isWebAppBannerDismissed, setIsWebAppBannerDismissed] = useState(false);
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  // Load the dismissed state on mount
+  useEffect(() => {
+    const loadDismissedState = async () => {
+      try {
+        const value = await AsyncStorage.getItem(WEB_APP_BANNER_DISMISSED_KEY);
+        setIsWebAppBannerDismissed(value === "true");
+      } catch (error) {
+        console.error("Failed to load banner state:", error);
+      } finally {
+        setIsInitialized(true);
+      }
+    };
+
+    loadDismissedState();
+  }, []);
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        outerContainer: {
+          position: "relative",
+          zIndex: 1,
+          width: "100%",
+        },
+        container: {
+          backgroundColor: theme.colors.primaryContainer,
+          paddingVertical: 8,
+          paddingHorizontal: 16,
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 8,
+          minHeight: 44,
+        },
+        content: {
+          flex: 1,
+          flexDirection: "row",
+          alignItems: "center",
+          gap: 8,
+        },
+        text: {
+          color: theme.colors.onPrimaryContainer,
+          ...theme.fonts.bodySmall,
+        },
+        dismissButton: {
+          padding: 4,
+        },
+      }),
+    [theme],
+  );
+
+  const shouldShow = Platform.OS === "web" && !isWebAppBannerDismissed;
+
+  const handlePress = useCallback(() => {
+    router.push("/download");
+  }, [router]);
+
+  const handleDismiss = useCallback(async () => {
+    setIsWebAppBannerDismissed(true);
+    try {
+      await AsyncStorage.setItem(WEB_APP_BANNER_DISMISSED_KEY, "true");
+    } catch (error) {
+      console.error("Failed to save banner state:", error);
+    }
+  }, []);
+
+  if (!shouldShow || !isInitialized) {
+    return null;
+  }
+
+  return (
+    <View style={styles.outerContainer}>
+      <View style={styles.container}>
+        <Pressable style={styles.content} onPress={handlePress}>
+          <MaterialCommunityIcons
+            name="cellphone"
+            size={16}
+            color={theme.colors.onPrimaryContainer}
+          />
+          <Text style={styles.text}>
+            Try AudioPlayground on iOS and Android — your feedback is appreciated!
+          </Text>
+        </Pressable>
+        <Pressable
+          style={styles.dismissButton}
+          onPress={handleDismiss}
+        >
+          <MaterialCommunityIcons
+            name="close"
+            size={16}
+            color={theme.colors.onPrimaryContainer}
+          />
+        </Pressable>
+      </View>
+    </View>
+  );
+}; 

--- a/documentation_site/docs/playground.md
+++ b/documentation_site/docs/playground.md
@@ -19,6 +19,23 @@ sidebar_label: Playground Application
   </div>
 </div>
 
+<div style={{display: "flex", flexDirection: "column", alignItems: "center", margin: "20px 0"}}>
+  <p><strong>Download AudioPlayground to experience all features on your device</strong></p>
+  <div style={{display: "flex", justifyContent: "center", gap: "20px", margin: "10px 0"}}>
+    <a href="https://apps.apple.com/app/audio-playground/id6739774966">
+      <img src="https://developer.apple.com/app-store/marketing/guidelines/images/badge-download-on-the-app-store.svg" alt="Download on the App Store" height="40" />
+    </a>
+    <a href="https://play.google.com/store/apps/details?id=net.siteed.audioplayground">
+      <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="40" />
+    </a>
+    <a href="https://deeeed.github.io/expo-audio-stream/playground" style={{textDecoration: "none"}}>
+      <div style={{display: "inline-block", padding: "10px 20px", backgroundColor: "#007bff", color: "white", borderRadius: "5px", fontSize: "16px"}}>
+        Try it on the Web
+      </div>
+    </a>
+  </div>
+</div>
+
 The playground application is a showcase for the `@siteed/expo-audio-studio` library. It demonstrates the various features of the library and provides visualizations for different audio features.
 
 ## Features

--- a/packages/expo-audio-studio/README.md
+++ b/packages/expo-audio-studio/README.md
@@ -21,6 +21,18 @@
     </div>
   </div>
 
+  <div style="display: flex; flex-direction: column; align-items: center; margin-bottom: 20px;">
+    <p><strong>Try AudioPlayground: Complete audio processing app built with this library</strong></p>
+    <div style="display: flex; justify-content: center; gap: 20px; margin: 10px 0;">
+      <a href="https://apps.apple.com/app/audio-playground/id6739774966">
+        <img src="https://developer.apple.com/app-store/marketing/guidelines/images/badge-download-on-the-app-store.svg" alt="Download on the App Store" height="40" />
+      </a>
+      <a href="https://play.google.com/store/apps/details?id=net.siteed.audioplayground">
+        <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="40" />
+      </a>
+    </div>
+  </div>
+
   <a href="https://deeeed.github.io/expo-audio-stream/playground" style="text-decoration:none;">
     <div style="display:inline-block; padding:10px 20px; background-color:#007bff; color:white; border-radius:5px; font-size:16px;">
       Try it in the Playground


### PR DESCRIPTION
# Description
This PR rebrands the project from `expo-audio-stream` to `expo-audio-studio` and improves app discoverability with download links and promotional components.

**Purpose and Impact**:
- Updates project name to `expo-audio-studio` across documentation and issue templates.
- Adds App Store and Google Play download links in READMEs and documentation.
- Introduces `DownloadPage` and `WebAppBanner` components to promote app downloads.
- Enhances bug report template with cross-platform validation steps.

**Key Changes**:
- Updated READMEs with app store badges and web demo links.
- Revised `.github/ISSUE_TEMPLATE/bug_report.md` for `expo-audio-studio` and added platform testing guidance.
- Added `apps/playground/src/app/download.tsx` for a dedicated download page.
- Implemented `apps/playground/src/components/WebAppBanner.tsx` for web-based app promotion.
- Updated `apps/playground/PUBLISH_STORE.md` with app availability URLs.
- Modified navigation in `apps/playground/src/app/(tabs)/more.tsx` and `apps/playground/src/app/_layout.tsx` for download access.
