### PR TITLE
feat: support buffer duration and skip file writing settings

### DIFF
--- a/documentation_site/docs/api-reference/API/interfaces/RecordingConfig.md
+++ b/documentation_site/docs/api-reference/API/interfaces/RecordingConfig.md
@@ -140,6 +140,28 @@ Interval in milliseconds at which to emit analysis data
 
 ***
 
+### bufferDurationSeconds?
+
+> `optional` **bufferDurationSeconds**: `number`
+
+Defined in: [src/ExpoAudioStream.types.ts:371](https://github.com/deeeed/expo-audio-stream/blob/5d8518e2259372c13fd38b3adc7b767434cbd154/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L371)
+
+Buffer duration in seconds. If not set, we use default buffer AVAudioFrameCount of 1024.
+
+***
+
+### skipFileWriting?
+
+> `optional` **skipFileWriting**: `boolean`
+
+Defined in: [src/ExpoAudioStream.types.ts:369](https://github.com/deeeed/expo-audio-stream/blob/5d8518e2259372c13fd38b3adc7b767434cbd154/packages/expo-audio-studio/src/ExpoAudioStream.types.ts#L369)
+
+When true, only emits audio data without writing to file
+
+***
+
+
+
 ### ios?
 
 > `optional` **ios**: [`IOSConfig`](IOSConfig.md)

--- a/packages/expo-audio-studio/ios/AudioStreamManager.swift
+++ b/packages/expo-audio-studio/ios/AudioStreamManager.swift
@@ -102,6 +102,9 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
     
     // Add property to track auto-resume preference
     private var autoResumeAfterInterruption: Bool = false
+
+    private var bufferDurationSeconds: Double?
+    private var skipFileWriting: Bool = false
     
     // Add these properties
     private var emissionInterval: TimeInterval = 1.0  // Default 1 second

--- a/packages/expo-audio-studio/ios/AudioStreamManager.swift
+++ b/packages/expo-audio-studio/ios/AudioStreamManager.swift
@@ -709,9 +709,9 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
         }
         
         // Install the tap with hardware format
-        var bufferSize = 1024
+        var bufferSize: AVAudioFrameCount = 1024
         if let bufferDurationSeconds = bufferDurationSeconds {
-            bufferSize = Int(bufferDurationSeconds * Double(inputHardwareFormat.sampleRate))
+            bufferSize = AVAudioFrameCount(bufferDurationSeconds * Double(inputHardwareFormat.sampleRate))
         }
         inputNode.installTap(onBus: 0, bufferSize: bufferSize, format: inputHardwareFormat, block: tapBlock)
         Logger.debug("AudioStreamManager", "Tap installed with hardware-compatible format")

--- a/packages/expo-audio-studio/ios/AudioStreamManager.swift
+++ b/packages/expo-audio-studio/ios/AudioStreamManager.swift
@@ -1008,9 +1008,13 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             return nil
         }
         
-        guard let settings = recordingSettings, 
-              let fileUri = recordingFileURL?.absoluteString else {
-            Logger.debug("Missing settings or file URI")
+        guard let settings = recordingSettings else {
+            Logger.debug("Missing settings")
+            return nil
+        }
+        
+        if !skipFileWriting, recordingFileURL?.absoluteString == nil {
+            Logger.debug("Missing file URI")
             return nil
         }
         

--- a/packages/expo-audio-studio/ios/AudioStreamManager.swift
+++ b/packages/expo-audio-studio/ios/AudioStreamManager.swift
@@ -877,6 +877,11 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             Logger.debug("AudioStreamManager", "  - channels: \(settings.numberOfChannels)")
             Logger.debug("AudioStreamManager", "  - bit depth: \(settings.bitDepth)-bit")
             Logger.debug("AudioStreamManager", "  - compression enabled: \(settings.enableCompressedOutput)")
+            if let bufferDurationSeconds {
+                Logger.debug("AudioStreamManager", "  - buffer size: \(bufferDurationSeconds)")
+            }
+            Logger.debug("AudioStreamManager", "  - skip file writing: \(skipFileWriting)")
+
 
             // Use our shared tap installation method
             let tapFormat = installTapWithHardwareFormat()

--- a/packages/expo-audio-studio/ios/ExpoAudioStreamModule.swift
+++ b/packages/expo-audio-studio/ios/ExpoAudioStreamModule.swift
@@ -156,6 +156,8 @@ public class ExpoAudioStreamModule: Module, AudioStreamManagerDelegate {
         ///       - `enabled`: Boolean to enable/disable compression (default is false).
         ///       - `format`: The compression format (default is "aac").
         ///       - `bitrate`: The compression bitrate in bps (default is 128000).
+        ///     - `bufferDurationSeconds`: The buffer duration in seconds (default is 0.02 seconds).
+        ///     - `skipFileWriting`: When true, only emits audio data without writing to file (default is false).
         ///   - promise: A promise to resolve with the recording settings or reject with an error.
         AsyncFunction("startRecording") { (options: [String: Any], promise: Promise) in
             Logger.debug("ExpoAudioStreamModule", "startRecording called with options: \(options)")

--- a/packages/expo-audio-studio/ios/ExpoAudioStreamModule.swift
+++ b/packages/expo-audio-studio/ios/ExpoAudioStreamModule.swift
@@ -156,7 +156,7 @@ public class ExpoAudioStreamModule: Module, AudioStreamManagerDelegate {
         ///       - `enabled`: Boolean to enable/disable compression (default is false).
         ///       - `format`: The compression format (default is "aac").
         ///       - `bitrate`: The compression bitrate in bps (default is 128000).
-        ///     - `bufferDurationSeconds`: The buffer duration in seconds (default is 0.02 seconds).
+        ///     - `bufferDurationSeconds`: The buffer duration in seconds (if no value we set a default buffer size).
         ///     - `skipFileWriting`: When true, only emits audio data without writing to file (default is false).
         ///   - promise: A promise to resolve with the recording settings or reject with an error.
         AsyncFunction("startRecording") { (options: [String: Any], promise: Promise) in

--- a/packages/expo-audio-studio/ios/RecordingResult.swift
+++ b/packages/expo-audio-studio/ios/RecordingResult.swift
@@ -1,7 +1,9 @@
 // RecordingResult.swift
 
 struct RecordingResult {
+    /// Empty if skipped file writing
     var fileUri: String
+    /// Empty if skipped file writing
     var filename: String
     var mimeType: String
     var duration: Int64
@@ -13,6 +15,7 @@ struct RecordingResult {
 }
 
 struct StartRecordingResult {
+    /// Empty if skipped file writing
     var fileUri: String
     var mimeType: String
     var channels: Int

--- a/packages/expo-audio-studio/ios/RecordingSettings.swift
+++ b/packages/expo-audio-studio/ios/RecordingSettings.swift
@@ -77,7 +77,7 @@ enum RecordingError: Error {
 struct RecordingSettings {
     // Core recording settings
     var sampleRate: Double
-    var bufferDurationSeconds: Double = 0.02
+    var bufferDurationSeconds: Double?
     var numberOfChannels: Int = 1
     var bitDepth: Int = 16
     var interval: Int?
@@ -151,6 +151,8 @@ struct RecordingSettings {
         settings.bitDepth = dict["bitDepth"] as? Int ?? 16
         settings.interval = dict["interval"] as? Int
         settings.intervalAnalysis = dict["intervalAnalysis"] as? Int
+        settings.bufferDurationSeconds = dict["bufferDurationSeconds"] as? Double
+        settings.skipFileWriting = dict["skipFileWriting"] as? Bool ?? false
         
         // Parse feature flags
         settings.keepAwake = dict["keepAwake"] as? Bool ?? true

--- a/packages/expo-audio-studio/ios/RecordingSettings.swift
+++ b/packages/expo-audio-studio/ios/RecordingSettings.swift
@@ -77,7 +77,6 @@ enum RecordingError: Error {
 struct RecordingSettings {
     // Core recording settings
     var sampleRate: Double
-    var desiredSampleRate: Double
     var bufferDurationSeconds: Double = 0.02
     var numberOfChannels: Int = 1
     var bitDepth: Int = 16
@@ -141,7 +140,6 @@ struct RecordingSettings {
         // Create settings
         var settings = RecordingSettings(
             sampleRate: dict["sampleRate"] as? Double ?? 44100.0,
-            desiredSampleRate: dict["desiredSampleRate"] as? Double ?? 44100.0,
             enableCompressedOutput: enableCompressedOutput,
             compressedFormat: compressedFormat,
             compressedBitRate: compressedBitRate,

--- a/packages/expo-audio-studio/ios/RecordingSettings.swift
+++ b/packages/expo-audio-studio/ios/RecordingSettings.swift
@@ -78,10 +78,13 @@ struct RecordingSettings {
     // Core recording settings
     var sampleRate: Double
     var desiredSampleRate: Double
+    var bufferDurationSeconds: Double = 0.02
     var numberOfChannels: Int = 1
     var bitDepth: Int = 16
     var interval: Int?
     var intervalAnalysis: Int?
+    /// When true, only emits audio data without writing to file
+    var skipFileWriting: Bool = false
     
     // Feature flags
     var keepAwake: Bool = true

--- a/packages/expo-audio-studio/src/ExpoAudioStream.types.ts
+++ b/packages/expo-audio-studio/src/ExpoAudioStream.types.ts
@@ -370,6 +370,12 @@ export interface RecordingConfig {
 
     /** How to handle device disconnection during recording */
     deviceDisconnectionBehavior?: DeviceDisconnectionBehaviorType
+
+    /** When true, only emits audio data without writing to file */
+    skipFileWriting?: boolean
+
+    /** Buffer duration in seconds. If not set, we use default buffer AVAudioFrameCount of 1024. */
+    bufferDurationSeconds?: number
 }
 
 export interface NotificationConfig {


### PR DESCRIPTION
- Controlling buffer durations helps ensuring we receive buffers that are compatible with specific codecs
- There are scenarios where we only need emitted audio data and not the written file

