### PR TITLE
fix: iOS: If primary file writing is disabled, no audio data is ever provided for streaming (#257)

### DIFF
--- a/packages/expo-audio-studio/ios/AudioStreamManager.swift
+++ b/packages/expo-audio-studio/ios/AudioStreamManager.swift
@@ -696,12 +696,11 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
         // Create the default tap block if none provided
         let tapBlock = customTapBlock ?? { [weak self] (buffer, time) in
             guard let self = self,
-                  let fileURL = self.recordingFileURL,
                   self.isRecording else {
                 return
             }
             // processAudioBuffer will handle resampling if needed
-            self.processAudioBuffer(buffer, fileURL: fileURL)
+            self.processAudioBuffer(buffer)
             self.lastBufferTime = time
         }
         
@@ -1404,8 +1403,7 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
     /// analysis processing and event emission based on intervals.
     /// - Parameters:
     ///   - buffer: The audio buffer received from the input node tap.
-    ///   - fileURL: The URL of the file to write the data to (ignored, uses self.fileHandle).
-    private func processAudioBuffer(_ buffer: AVAudioPCMBuffer, fileURL: URL) {
+    private func processAudioBuffer(_ buffer: AVAudioPCMBuffer) {
         guard let settings = recordingSettings else {
             Logger.debug("processAudioBuffer: Recording settings not available")
             return
@@ -2104,7 +2102,7 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
                 guard let self = self, self.isRecording else { return }
                 
                 // Process the buffer normally - processAudioBuffer handles all emission logic
-                self.processAudioBuffer(buffer, fileURL: self.recordingFileURL!)
+                self.processAudioBuffer(buffer)
                 self.lastBufferTime = time
             }
             


### PR DESCRIPTION
## Description
This change fixes audio data not being provided if primary file writing is disabled (e.g. for streaming) on iOS. 

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

## Architecture Decision
This bug was caused by installTapWithHardwareFormat guarding for self.recordingFileURL so that it could pass the file url into processAudioBuffer. The processAudioBuffer function signature required fileURL, but it was never used (it even mentioned it was ignored in comments). Internally the file already correctly used self.fileHandle if needed. I simply removed the unused input and removed the guard.

All changes were in AudioStreamManager.swift


### Testing
I verified this change fixes the bug in my own Expo app, but I am not currently familiar enough with this project to run existing automated testing or build verification. Happy to look into this if I can get a quick overview of the process.