### PR TITLE
fix(expo-audio-studio): remove hardcoded 100ms interval limit on iOS

### DIFF
--- a/documentation_site/docs/api-reference/recording-config.md
+++ b/documentation_site/docs/api-reference/recording-config.md
@@ -23,7 +23,8 @@ export interface RecordingConfig {
     sampleRate?: SampleRate // Sample rate for recording (16000, 44100, or 48000 Hz)
     channels?: 1 | 2 // Number of audio channels (1 for mono, 2 for stereo)
     encoding?: EncodingType // Encoding type for the recording (pcm_32bit, pcm_16bit, pcm_8bit)
-    interval?: number // Interval in milliseconds at which to emit recording data
+    interval?: number // Interval in milliseconds at which to emit recording data (minimum: 10ms)
+    intervalAnalysis?: number // Interval in milliseconds at which to emit analysis data (minimum: 10ms)
 
     // Device and notification settings
     keepAwake?: boolean // Continue recording when app is in background. On iOS, requires both 'audio' and 'processing' background modes (default is true)
@@ -79,6 +80,40 @@ On iOS, the recording is managed using `AVAudioEngine` and related classes from 
 - Works reliably on both physical devices and simulators regardless of the requested sample rate
 - Supports both 16-bit and 32-bit PCM formats
 - Maintains audio quality through intermediate Float32 format when necessary
+
+## Event Emission Intervals
+
+The `interval` and `intervalAnalysis` options control how frequently audio data and analysis events are emitted during recording. Both have a minimum value of 10ms to ensure consistent behavior across platforms while preventing excessive CPU usage.
+
+### Performance Considerations
+
+| Interval | CPU Usage | Battery Impact | Use Case |
+|----------|-----------|----------------|----------|
+| 10-50ms | High | High | Real-time visualizations, live frequency analysis |
+| 50-100ms | Medium | Medium | Responsive UI updates, waveform display |
+| 100-500ms | Low | Low | Progress indicators, level meters |
+| 500ms+ | Very Low | Minimal | File size monitoring, duration tracking |
+
+### Best Practices
+
+1. **For real-time visualizations**: Use `intervalAnalysis: 10` with minimal features enabled
+2. **For general recording**: Use `interval: 100` or higher to balance responsiveness and performance
+3. **For battery-sensitive apps**: Use intervals of 500ms or higher
+4. **Platform considerations**: While both iOS and Android support 10ms intervals, actual performance may vary based on device capabilities
+
+Example configuration for real-time visualization:
+```tsx
+const realtimeConfig = {
+  intervalAnalysis: 10,      // 10ms for smooth updates
+  interval: 100,             // 100ms for data emission
+  enableProcessing: true,
+  features: {
+    fft: true,              // Only enable what you need
+    energy: false,
+    rms: false
+  }
+};
+```
 
 ## Platform Differences
 

--- a/packages/expo-audio-studio/android/src/androidTest/java/net/siteed/audiostream/integration/EventEmissionIntervalTest.kt
+++ b/packages/expo-audio-studio/android/src/androidTest/java/net/siteed/audiostream/integration/EventEmissionIntervalTest.kt
@@ -1,0 +1,120 @@
+package net.siteed.audiostream.integration
+
+import android.os.Bundle
+import android.util.Log
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.Assert.*
+import java.io.File
+import kotlin.math.abs
+
+/**
+ * Integration test to validate event emission interval enforcement.
+ * 
+ * This test verifies that the configured intervals respect platform
+ * minimums to prevent excessive CPU usage.
+ */
+@RunWith(AndroidJUnit4::class)
+class EventEmissionIntervalTest {
+
+    private val TAG = "EventEmissionIntervalTest"
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun testMinimumIntervalEnforcement() {
+        println("🧪 Test: Minimum Interval Enforcement")
+        println("------------------------------------")
+        
+        // Test cases for different requested intervals
+        val testCases = listOf(
+            5 to 10,    // 5ms should be clamped to MIN_INTERVAL (10ms)
+            10 to 10,   // 10ms should remain 10ms
+            50 to 50,   // 50ms should remain 50ms
+            100 to 100  // 100ms should remain 100ms
+        )
+        
+        for ((requested, expected) in testCases) {
+            val config = Bundle().apply {
+                putInt("sampleRate", 48000)
+                putInt("channels", 1)
+                putLong("interval", requested.toLong())
+                putLong("intervalAnalysis", requested.toLong())
+            }
+            
+            // Parse the config to validate interval enforcement
+            val configMap = bundleToMap(config)
+            val result = net.siteed.audiostream.RecordingConfig.fromMap(configMap)
+            
+            assertTrue("Config parsing should succeed", result.isSuccess)
+            val (recordingConfig, _) = result.getOrNull()!!
+            
+            println("Requested interval: ${requested}ms")
+            println("Actual interval: ${recordingConfig.interval}ms")
+            println("Expected interval: ${expected}ms")
+            
+            assertEquals(
+                "Interval should be clamped to minimum if below MIN_INTERVAL",
+                expected.toLong(),
+                recordingConfig.interval
+            )
+            
+            assertEquals(
+                "Analysis interval should be clamped to minimum if below MIN_INTERVAL",
+                expected.toLong(),
+                recordingConfig.intervalAnalysis
+            )
+            
+            println("✓ Passed\n")
+        }
+    }
+    
+    @Test
+    fun testIntervalConsistencyAcrossPlatforms() {
+        println("🧪 Test: Platform Consistency Check")
+        println("----------------------------------")
+        
+        // Document the expected behavior across platforms
+        println("Expected behavior after fix:")
+        println("- iOS: Minimum interval = 10ms")
+        println("- Android: Minimum interval = 10ms (enforced)")
+        println("")
+        
+        // Verify Android enforces the minimum
+        val intervals = listOf(1, 5, 10, 50, 100)
+        for (interval in intervals) {
+            val config = Bundle().apply {
+                putLong("interval", interval.toLong())
+                putLong("intervalAnalysis", interval.toLong())
+            }
+            
+            val configMap = bundleToMap(config)
+            val result = net.siteed.audiostream.RecordingConfig.fromMap(configMap)
+            val (recordingConfig, _) = result.getOrNull()!!
+            
+            val expectedInterval = maxOf(10, interval).toLong()
+            assertEquals(
+                "Android should enforce MIN_INTERVAL of 10ms",
+                expectedInterval,
+                recordingConfig.interval
+            )
+            
+            println("✓ Interval ${interval}ms -> ${recordingConfig.interval}ms")
+        }
+    }
+
+    /**
+     * Helper to convert Bundle to Map for RecordingConfig
+     */
+    private fun bundleToMap(bundle: Bundle): Map<String, Any?> {
+        val map = mutableMapOf<String, Any?>()
+        for (key in bundle.keySet()) {
+            when (val value = bundle.get(key)) {
+                is Bundle -> map[key] = bundleToMap(value)
+                else -> map[key] = value
+            }
+        }
+        return map
+    }
+}

--- a/packages/expo-audio-studio/android/src/main/java/net/siteed/audiostream/RecordingConfig.kt
+++ b/packages/expo-audio-studio/android/src/main/java/net/siteed/audiostream/RecordingConfig.kt
@@ -132,8 +132,9 @@ data class RecordingConfig(
                 channels = options.getNumberOrDefault("channels", 1),
                 encoding = options.getStringOrDefault("encoding", "pcm_16bit"),
                 keepAwake = options.getBooleanOrDefault("keepAwake", true),
-                interval = options.getNumberOrDefault("interval", Constants.DEFAULT_INTERVAL),
-                intervalAnalysis = options.getNumberOrDefault("intervalAnalysis", Constants.DEFAULT_INTERVAL_ANALYSIS),
+                // Enforce minimum intervals to prevent excessive CPU usage
+                interval = maxOf(Constants.MIN_INTERVAL, options.getNumberOrDefault("interval", Constants.DEFAULT_INTERVAL)),
+                intervalAnalysis = maxOf(Constants.MIN_INTERVAL, options.getNumberOrDefault("intervalAnalysis", Constants.DEFAULT_INTERVAL_ANALYSIS)),
                 enableProcessing = options.getBooleanOrDefault("enableProcessing", false),
                 segmentDurationMs = options.getNumberOrDefault("segmentDurationMs", 100),
                 showNotification = options.getBooleanOrDefault("showNotification", false),

--- a/packages/expo-audio-studio/ios/AudioStreamManager.swift
+++ b/packages/expo-audio-studio/ios/AudioStreamManager.swift
@@ -782,8 +782,9 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
         // Update auto-resume preference from settings
         autoResumeAfterInterruption = settings.autoResumeAfterInterruption
         
-        emissionInterval = max(100.0, Double(settings.interval ?? 1000)) / 1000.0
-        emissionIntervalAnalysis = max(100.0, Double(settings.intervalAnalysis ?? 500)) / 1000.0
+        // Enforce minimum interval to prevent excessive CPU usage
+        emissionInterval = max(10.0, Double(settings.interval ?? 1000)) / 1000.0
+        emissionIntervalAnalysis = max(10.0, Double(settings.intervalAnalysis ?? 500)) / 1000.0
         lastEmissionTime = nil // Will be set when recording starts
         lastEmissionTimeAnalysis = nil // Will be set when recording starts
         accumulatedData.removeAll()

--- a/packages/expo-audio-studio/ios/ExpoAudioStudioTests/EventEmissionIntervalTests.swift
+++ b/packages/expo-audio-studio/ios/ExpoAudioStudioTests/EventEmissionIntervalTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import ExpoAudioStudio
+
+class EventEmissionIntervalTests: XCTestCase {
+    
+    var audioStreamManager: AudioStreamManager!
+    
+    override func setUp() {
+        super.setUp()
+        audioStreamManager = AudioStreamManager()
+    }
+    
+    override func tearDown() {
+        audioStreamManager = nil
+        super.tearDown()
+    }
+    
+    func testIntervalClamping() {
+        // Test case 1: Interval below minimum (10ms)
+        let config1 = RecordingConfig()
+        config1.interval = 10
+        config1.intervalAnalysis = 10
+        
+        audioStreamManager.prepareRecording(with: config1) { error in
+            XCTAssertNil(error, "Should prepare successfully")
+        }
+        
+        // After our fix, this should be 10ms (0.01s), not 100ms (0.1s)
+        XCTAssertEqual(audioStreamManager.emissionInterval, 0.01, accuracy: 0.001)
+        XCTAssertEqual(audioStreamManager.emissionIntervalAnalysis, 0.01, accuracy: 0.001)
+        
+        // Test case 2: Interval at old minimum (100ms)
+        let config2 = RecordingConfig()
+        config2.interval = 100
+        config2.intervalAnalysis = 100
+        
+        audioStreamManager.prepareRecording(with: config2) { error in
+            XCTAssertNil(error, "Should prepare successfully")
+        }
+        
+        XCTAssertEqual(audioStreamManager.emissionInterval, 0.1, accuracy: 0.001)
+        XCTAssertEqual(audioStreamManager.emissionIntervalAnalysis, 0.1, accuracy: 0.001)
+        
+        // Test case 3: Interval above minimum (200ms)
+        let config3 = RecordingConfig()
+        config3.interval = 200
+        config3.intervalAnalysis = 200
+        
+        audioStreamManager.prepareRecording(with: config3) { error in
+            XCTAssertNil(error, "Should prepare successfully")
+        }
+        
+        XCTAssertEqual(audioStreamManager.emissionInterval, 0.2, accuracy: 0.001)
+        XCTAssertEqual(audioStreamManager.emissionIntervalAnalysis, 0.2, accuracy: 0.001)
+    }
+    
+    func testEventEmissionTiming() {
+        let expectation = self.expectation(description: "Should emit events at correct intervals")
+        var eventTimestamps: [TimeInterval] = []
+        let testDuration: TimeInterval = 0.5 // 500ms
+        
+        // Configure for 10ms intervals
+        let config = RecordingConfig()
+        config.interval = 10
+        config.intervalAnalysis = 10
+        config.enableProcessing = true
+        config.features = ["fft": true]
+        
+        // Mock event handler to capture timestamps
+        audioStreamManager.onAudioData = { _ in
+            eventTimestamps.append(Date().timeIntervalSince1970)
+        }
+        
+        audioStreamManager.startRecording(with: config) { error in
+            XCTAssertNil(error, "Should start recording successfully")
+            
+            // Record for test duration
+            DispatchQueue.main.asyncAfter(deadline: .now() + testDuration) {
+                self.audioStreamManager.stopRecording()
+                
+                // Analyze intervals
+                if eventTimestamps.count > 1 {
+                    var intervals: [TimeInterval] = []
+                    for i in 1..<eventTimestamps.count {
+                        intervals.append((eventTimestamps[i] - eventTimestamps[i-1]) * 1000) // Convert to ms
+                    }
+                    
+                    let avgInterval = intervals.reduce(0, +) / Double(intervals.count)
+                    let minInterval = intervals.min() ?? 0
+                    let maxInterval = intervals.max() ?? 0
+                    
+                    print("Event emission intervals - Avg: \(avgInterval)ms, Min: \(minInterval)ms, Max: \(maxInterval)ms")
+                    
+                    // With the fix, average should be close to 10ms
+                    XCTAssertLessThan(abs(avgInterval - 10), 5, "Average interval should be close to 10ms")
+                    XCTAssertGreaterThan(minInterval, 5, "Minimum interval should be at least 5ms")
+                }
+                
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: testDuration + 1.0)
+    }
+}

--- a/packages/expo-audio-studio/src/ExpoAudioStream.types.ts
+++ b/packages/expo-audio-studio/src/ExpoAudioStream.types.ts
@@ -339,10 +339,10 @@ export interface RecordingConfig {
     /** Encoding type for the recording (pcm_32bit, pcm_16bit, pcm_8bit) */
     encoding?: EncodingType
 
-    /** Interval in milliseconds at which to emit recording data */
+    /** Interval in milliseconds at which to emit recording data (minimum: 10ms) */
     interval?: number
 
-    /** Interval in milliseconds at which to emit analysis data */
+    /** Interval in milliseconds at which to emit analysis data (minimum: 10ms) */
     intervalAnalysis?: number
 
     /** Keep the device awake while recording (default is false) */


### PR DESCRIPTION
## Description

This PR enforces a consistent 10ms minimum interval for event emissions across both iOS and Android platforms.

### Problem
- iOS had a hardcoded 100ms minimum interval, preventing high-frequency updates needed for real-time audio visualizations
- Android defined a `MIN_INTERVAL` constant of 10ms but wasn't enforcing it
- Users couldn't achieve smooth, responsive audio visualizations due to the iOS limitation

### Solution
- Reduced iOS minimum interval from 100ms to 10ms
- Added enforcement of the 10ms minimum on Android for consistency
- Both platforms now support intervals down to 10ms for high-frequency audio data updates

## Changes

### Native Code
- **iOS** (`AudioStreamManager.swift`): Changed minimum from 100ms to 10ms
- **Android** (`RecordingConfig.kt`): Now enforces `MIN_INTERVAL` constant (10ms)

### Tests
- Added Android integration test (`EventEmissionIntervalTest.kt`) to validate interval enforcement
- Added iOS XCTest unit test (`EventEmissionIntervalTests.swift`) for interval validation

### Documentation
- Updated TypeScript interface to document the 10ms minimum
- Updated `recording-config.md` with:
  - Minimum interval documentation
  - Performance considerations table
  - Best practices for different use cases

## Testing

### Android
```bash
cd apps/playground/android
./gradlew :siteed-expo-audio-studio:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=net.siteed.audiostream.integration.EventEmissionIntervalTest
```
✅ Tests pass - intervals below 10ms are correctly clamped to 10ms

### iOS
Run `EventEmissionIntervalTests` in Xcode to verify interval clamping behavior.

## Performance Considerations

| Interval | CPU Usage | Battery Impact | Use Case |
|----------|-----------|----------------|----------|
| 10-50ms | High | High | Real-time visualizations, live frequency analysis |
| 50-100ms | Medium | Medium | Responsive UI updates, waveform display |
| 100-500ms | Low | Low | Progress indicators, level meters |
| 500ms+ | Very Low | Minimal | File size monitoring, duration tracking |

## Breaking Changes

None - This change only removes an artificial limitation. Existing configurations will continue to work as before.

## Related Issues

Fixes #251