### PR TITLE
fix(ios): ensure the AVAudioSession is active in resumeRecording

### DIFF
--- a/packages/expo-audio-studio/ios/AudioStreamManager.swift
+++ b/packages/expo-audio-studio/ios/AudioStreamManager.swift
@@ -1184,23 +1184,16 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
         }
         
         do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.playAndRecord, mode: .default, options: [.allowBluetooth, .mixWithOthers])
+            try session.setActive(true, options: .notifyOthersOnDeactivation)
+            
             // Check and reinstall tap with hardware format
             _ = installTapWithHardwareFormat()
             Logger.debug("Tap reinstalled for resume")
             
-            // Try to restart the engine
-            try audioEngine.start()
-            
-            // Resume the compressed recorder if active
-            compressedRecorder?.record()
-            
             // Update state
             isPaused = false
-            
-            // Update notification state if enabled
-            if recordingSettings?.showNotification == true {
-                updateNotificationState(isPaused: false)
-            }
             
             // Clear the stored valid duration
             lastValidDuration = nil
@@ -1208,6 +1201,17 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             // Reset emission timers to ensure emission starts immediately after resume
             lastEmissionTime = Date()
             lastEmissionTimeAnalysis = Date()
+            
+            // Try to restart the engine
+            try audioEngine.start()
+            
+            // Resume the compressed recorder if active
+            compressedRecorder?.record()
+            
+            // Update notification state if enabled
+            if recordingSettings?.showNotification == true {
+                updateNotificationState(isPaused: false)
+            }
             
             // Notify delegate
             delegate?.audioStreamManager(self, didResumeRecording: Date())


### PR DESCRIPTION
## Description

I was facing issues with `resumeRecording` not sending `onAudioAnalysis` events. Turned out that `processAudioBuffer` wasn't being called at all! I tried calling `AVAudioSession.setActive(true)` before installing the tap, and that worked.

I also moved some variable updates to *before* the `audioEngine.start()` call, since that's how it's done in `startRecording`. This was my initial attempt at a fix, and while it had no effect, I decided to keep it, since it's more consistent.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Test-Driven Development Checklist

### Testing
- [ ] Unit tests included (recommended)
- [ ] iOS platform tests pass
- [ ] Android platform tests pass
- [ ] Integration tests included (when applicable)
- [ ] Cross-platform consistency verified
- [ ] Test coverage adequate for the change
- [ ] Edge cases and error scenarios considered
- [ ] Performance impact measured (if applicable)

### Test Evidence

*None yet. Only manual testing was done.*

## Documentation
- [ ] API documentation updated
- [ ] Usage examples added (if new feature)
- [ ] CHANGELOG.md updated
- [ ] README updated (if needed)

## Related Issues
<!-- Link to related issues: Fixes #123, Relates to #456 -->
—

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Tests are included (recommended for new features and bug fixes)
- [ ] Existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
